### PR TITLE
Support Boost 1.78

### DIFF
--- a/src/mock_ssl.hxx
+++ b/src/mock_ssl.hxx
@@ -29,6 +29,8 @@ public:
 class mock_ssl_socket {
 public:
     using lowest_layer_type = asio::ip::tcp::socket;
+    using handle_type = asio::posix::stream_descriptor;
+    using executor_type = handle_type::executor_type;
 
     mock_ssl_socket(asio::ip::tcp::socket& tcp_socket,
                     mock_ssl_context& context)


### PR DESCRIPTION
This is preparation for libc++13 support (https://github.com/ClickHouse/ClickHouse/pull/32484)

To be able to support boost 1.78 without SSL (`SSL_LIBRARY_NOT_FOUND=1`) the mock class needs a `executor_type`.