### PR TITLE
fix nuraft

### DIFF
--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -32,7 +32,6 @@ limitations under the License.
 namespace nuraft {
 
 void raft_server::enable_hb_for_peer(peer& p) {
-    p.enable_hb(true);
     p.resume_hb_speed();
     if (p.is_abandoned()) {
         timer_task<int32>::executor exec =
@@ -42,6 +41,7 @@ void raft_server::enable_hb_for_peer(peer& p) {
                     std::placeholders::_1 );
         p.reopen(*ctx_, exec);
     }
+    p.enable_hb(true);
     p_tr("peer %d, interval: %d\n", p.get_id(), p.get_current_hb_interval());
     schedule_task(p.get_hb_task(), p.get_current_hb_interval());
 }


### PR DESCRIPTION
https://github.com/ClickHouse/ClickHouse/pull/99133#discussion_r2922784458
The bumped `NuRaft` commit introduces a subtle heartbeat regression for reopened peers. In `raft_server::enable_hb_for_peer`, `p.enable_hb(true)` is called **before** the new `if (p.is_abandoned()) p.reopen(...)` branch. But `peer::enable_hb` returns early when `abandoned_` is true, so after `reopen` the peer still has `hb_enabled_ == false`; the first scheduled heartbeat runs once, then `handle_hb_timeout` does not reschedule because `is_hb_enabled()` is false.