### PR TITLE
Fix stale snapshot_sync_needed flag causing leader abort

### DIFF
--- a/include/libnuraft/raft_server_handler.hxx
+++ b/include/libnuraft/raft_server_handler.hxx
@@ -41,6 +41,13 @@ protected:
                                          raft_server::req_ext_params()) {
         return srv->process_req(req, ext_params);
     }
+
+    /**
+     * Get the peers map from a raft_server (for testing).
+     */
+    static std::unordered_map<int32, ptr<peer>>& get_peers(raft_server* srv) {
+        return srv->peers_;
+    }
 };
 
 }

--- a/include/libnuraft/raft_server_handler.hxx
+++ b/include/libnuraft/raft_server_handler.hxx
@@ -48,6 +48,20 @@ protected:
     static std::unordered_map<int32, ptr<peer>>& get_peers(raft_server* srv) {
         return srv->peers_;
     }
+
+    /**
+     * Check if the server believes it is out of log range (for testing).
+     */
+    static bool is_out_of_log_range(raft_server* srv) {
+        return srv->out_of_log_range_;
+    }
+
+    /**
+     * Get the last snapshot from a raft_server (for testing).
+     */
+    static ptr<snapshot> get_last_snapshot(raft_server* srv) {
+        return srv->get_last_snapshot();
+    }
 };
 
 }

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -484,7 +484,32 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,
     // Verify log index range.
     bool entries_valid = (last_log_idx + 1 >= starting_idx);
     if (entries_valid && pp->is_snapshot_sync_needed()) {
-        entries_valid = false;
+        // Check if the peer has already caught up past the snapshot.
+        // If so, clear the stale flag and proceed with normal log
+        // replication instead of incorrectly forcing entries_valid
+        // to false (which would send an erroneous out_of_log_range
+        // warning to the follower, blocking its election timer).
+        ptr<snapshot> snp_local = get_last_snapshot();
+        if (!snp_local || last_log_idx >= snp_local->get_last_log_idx()) {
+            // Either no snapshot exists (flag is stale — nothing to sync)
+            // or the peer has caught up past the snapshot. In both cases,
+            // clear the flag and proceed with normal log replication.
+            if (snp_local) {
+                p_in("peer %d log idx %" PRIu64 " has caught up past "
+                     "snapshot %" PRIu64 ", clearing stale snapshot sync "
+                     "flag before log replication",
+                     p.get_id(), last_log_idx,
+                     snp_local->get_last_log_idx());
+            } else {
+                p_in("peer %d log idx %" PRIu64 ", no snapshot exists, "
+                     "clearing stale snapshot sync flag",
+                     p.get_id(), last_log_idx);
+            }
+            clear_snapshot_sync_ctx(p);
+            pp->set_snapshot_sync_is_needed(false);
+        } else {
+            entries_valid = false;
+        }
     }
 
     // Read log entries. The underlying log store may have removed some log entries
@@ -552,6 +577,7 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,
                       "snapshot %" PRIu64 ", clearing snapshot sync flag",
                       p.get_id(), last_log_idx,
                       snp_local->get_last_log_idx() );
+                clear_snapshot_sync_ctx(p);
                 pp->set_snapshot_sync_is_needed(false);
                 // Fall through to log-based replication or OOL handling.
             } else {

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -543,18 +543,31 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,
              ( pp->is_snapshot_sync_needed() ||
                ( last_log_idx < starting_idx &&
                 last_log_idx < snp_local->get_last_log_idx() ) ) ) {
-            p_db( "send snapshot peer %d, peer log idx: %" PRIu64
-                  ", my starting idx: %" PRIu64 ", "
-                  "my log idx: %" PRIu64 ", last_snapshot_log_idx: %" PRIu64
-                  ", snapshot sync needed: %d",
-                  p.get_id(),
-                  last_log_idx, starting_idx, cur_nxt_idx,
-                  snp_local->get_last_log_idx(),
-                  pp->is_snapshot_sync_needed() );
+            // If peer has advanced past our snapshot, it doesn't need
+            // snapshot sync anymore — clear the flag and fall through
+            // to normal log replication or out-of-log-range handling.
+            if ( last_log_idx >= snp_local->get_last_log_idx() &&
+                 pp->is_snapshot_sync_needed() ) {
+                p_in( "peer %d log idx %" PRIu64 " has caught up past "
+                      "snapshot %" PRIu64 ", clearing snapshot sync flag",
+                      p.get_id(), last_log_idx,
+                      snp_local->get_last_log_idx() );
+                pp->set_snapshot_sync_is_needed(false);
+                // Fall through to log-based replication or OOL handling.
+            } else {
+                p_db( "send snapshot peer %d, peer log idx: %" PRIu64
+                      ", my starting idx: %" PRIu64 ", "
+                      "my log idx: %" PRIu64 ", last_snapshot_log_idx: %" PRIu64
+                      ", snapshot sync needed: %d",
+                      p.get_id(),
+                      last_log_idx, starting_idx, cur_nxt_idx,
+                      snp_local->get_last_log_idx(),
+                      pp->is_snapshot_sync_needed() );
 
-            bool succeeded_out = false;
-            return create_sync_snapshot_req( pp, last_log_idx, term,
-                                             commit_idx, succeeded_out );
+                bool succeeded_out = false;
+                return create_sync_snapshot_req( pp, last_log_idx, term,
+                                                 commit_idx, succeeded_out );
+            }
         }
 
         // Cannot recover using snapshot. Return here to protect the leader.

--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -113,7 +113,10 @@ ptr<req_msg> raft_server::create_sync_snapshot_req(ptr<peer>& pp,
     if ( !snp || sync_ctx->get_offset() == 0 ) {
         snp = get_last_snapshot();
         if ( snp == nilptr ) {
-            p_wn( "snapshot is not available for peer %d, will retry",
+            static timer_helper msg_timer(5000000);
+            int log_lv = msg_timer.timeout_and_reset() ? L_WARN : L_TRACE;
+            p_lv( log_lv,
+                  "snapshot is not available for peer %d, will retry",
                   p.get_id() );
             clear_snapshot_sync_ctx(p);
             return ptr<req_msg>();

--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -112,22 +112,23 @@ ptr<req_msg> raft_server::create_sync_snapshot_req(ptr<peer>& pp,
     //        last_snapshot_->get_last_log_idx() > snp->get_last_log_idx() )*/ ) {
     if ( !snp || sync_ctx->get_offset() == 0 ) {
         snp = get_last_snapshot();
-        if ( snp == nilptr ||
-             last_log_idx > snp->get_last_log_idx() ) {
-            // LCOV_EXCL_START
-            p_er( "system is running into fatal errors, failed to find a "
-                  "snapshot for peer %d (snapshot null: %d, snapshot "
-                  "doesn't contais lastLogIndex: %d)",
-                  p.get_id(), snp == nilptr ? 1 : 0,
-                  last_log_idx > snp->get_last_log_idx() ? 1 : 0 );
-            if (snp) {
-                p_er("last log idx %" PRIu64 ", snp last log idx %" PRIu64,
-                     last_log_idx, snp->get_last_log_idx());
-            }
-            ctx_->state_mgr_->system_exit(raft_err::N16_snapshot_for_peer_not_found);
-            _sys_exit(-1);
+        if ( snp == nilptr ) {
+            p_wn( "snapshot is not available for peer %d, will retry",
+                  p.get_id() );
+            clear_snapshot_sync_ctx(p);
             return ptr<req_msg>();
-            // LCOV_EXCL_STOP
+        }
+        if ( last_log_idx > snp->get_last_log_idx() ) {
+            p_wn( "peer %d's last log idx %" PRIu64 " is ahead of "
+                  "snapshot %" PRIu64 ", clearing snapshot sync state",
+                  p.get_id(), last_log_idx, snp->get_last_log_idx() );
+            // Peer has advanced past this snapshot — it doesn't need it.
+            // Clear sync state. If peer still needs catching up, the next
+            // call to request_append_entries will re-evaluate using the
+            // latest snapshot.
+            clear_snapshot_sync_ctx(p);
+            pp->set_snapshot_sync_is_needed(false);
+            return ptr<req_msg>();
         }
 
         if ( snp->get_type() == snapshot::raw_binary &&

--- a/tests/unit/fake_executer.hxx
+++ b/tests/unit/fake_executer.hxx
@@ -24,7 +24,7 @@ struct ExecArgs : TestSuite::ThreadArgs {
     std::atomic<bool> stopSignal;
     ptr<buffer> msgToWrite;
     std::mutex msgToWriteLock;
-    EventAwaiter eaExecuter;
+    nuraft::EventAwaiter eaExecuter;
 };
 
 static constexpr size_t EXECUTOR_WAIT_MS = 100;

--- a/tests/unit/fake_network.hxx
+++ b/tests/unit/fake_network.hxx
@@ -120,6 +120,33 @@ public:
         return false;
     }
 
+    bool isServerOutOfLogRange(raft_server* srv) {
+        return is_out_of_log_range(srv);
+    }
+
+    bool hasPeerSnapshotSyncCtx(raft_server* srv, int32 peer_id) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            return it->second->get_snapshot_sync_ctx() != nullptr;
+        }
+        return false;
+    }
+
+    void setPeerSnapshotInSync(raft_server* srv,
+                               int32 peer_id,
+                               ptr<snapshot> snp) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            it->second->set_snapshot_in_sync(snp);
+        }
+    }
+
+    ptr<snapshot> getLastSnapshot(raft_server* srv) {
+        return get_last_snapshot(srv);
+    }
+
 private:
     std::string myEndpoint;
     ptr<FakeNetworkBase> base;

--- a/tests/unit/fake_network.hxx
+++ b/tests/unit/fake_network.hxx
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "nuraft.hxx"
 
+#include "peer.hxx"
 #include "raft_server_handler.hxx"
 
 #include <map>
@@ -98,6 +99,26 @@ public:
     void stop();
 
     void shutdown();
+
+    void setPeerSnapshotSyncNeeded(raft_server* srv,
+                                   int32 peer_id,
+                                   bool val) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            it->second->set_snapshot_sync_is_needed(val);
+        }
+    }
+
+    bool getPeerSnapshotSyncNeeded(raft_server* srv,
+                                   int32 peer_id) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            return it->second->is_snapshot_sync_needed();
+        }
+        return false;
+    }
 
 private:
     std::string myEndpoint;

--- a/tests/unit/raft_package_fake.hxx
+++ b/tests/unit/raft_package_fake.hxx
@@ -175,7 +175,7 @@ static std::atomic<bool> commit_done(false);
 static std::list<int> removed_servers;
 static std::vector<RaftPkg*> pkgs_to_watch;
 static std::mutex pkgs_to_watch_lock;
-static EventAwaiter ea_wait_for_commit;
+static nuraft::EventAwaiter ea_wait_for_commit;
 
 static bool ATTR_UNUSED check_pkgs() {
     // Check if all current committed logs are executed in

--- a/tests/unit/snapshot_test.cxx
+++ b/tests/unit/snapshot_test.cxx
@@ -892,6 +892,14 @@ int snapshot_stale_sync_flag_test() {
 
     uint64_t s3_log_idx = s3.raftServer->get_last_log_idx();
 
+    // Leader must have a snapshot (snapshot_distance_=5, 10 entries appended).
+    // This ensures we exercise the "peer caught up past snapshot" path,
+    // not the "no snapshot exists" fallback.
+    ptr<snapshot> leader_snp =
+        s1.fNet->getLastSnapshot(s1.raftServer.get());
+    CHK_NONNULL( leader_snp.get() );
+    CHK_GTEQ( s3_log_idx, leader_snp->get_last_log_idx() );
+
     // --- Simulate the TOCTOU race condition ---
     // Force-set is_snapshot_sync_needed on the leader's peer for S3.
     // In production, this flag gets set via RECEIVING_SNAPSHOT response,
@@ -901,18 +909,41 @@ int snapshot_stale_sync_flag_test() {
     CHK_TRUE( s1.fNet->getPeerSnapshotSyncNeeded(
                   s1.raftServer.get(), 3) );
 
-    // Trigger heartbeat. With the old code, create_append_entries_req would
-    // enter create_sync_snapshot_req and call system_exit (abort) because
-    // peer's last_log_idx >= snapshot's last_log_idx.
-    // With the fix (Fix 2), the flag is cleared and the function falls
-    // through to normal replication or OOL handling.
+    // Also create a snapshot sync context on the peer, simulating a
+    // partial snapshot transfer that was interrupted. Without this,
+    // the hasPeerSnapshotSyncCtx assertion below would be vacuous
+    // (checking nullptr == nullptr).
+    s1.fNet->setPeerSnapshotInSync(
+        s1.raftServer.get(), 3, leader_snp);
+    CHK_TRUE( s1.fNet->hasPeerSnapshotSyncCtx(
+                  s1.raftServer.get(), 3) );
+
+    // Trigger heartbeat. With the old code, create_append_entries_req
+    // would enter create_sync_snapshot_req and call system_exit (abort)
+    // because peer's last_log_idx >= snapshot's last_log_idx.
+    // With the fix, the early check at the top of create_append_entries_req
+    // detects that entries_valid is true and the peer has caught up past
+    // the snapshot, clears both the flag and context, and proceeds with
+    // normal log replication.
     s1.fTimer->invoke( timer_task_type::heartbeat_timer );
     s1.fNet->execReqResp();
     s1.fNet->execReqResp();
 
-    // The flag should now be cleared by Fix 2.
+    // The flag should now be cleared.
     CHK_FALSE( s1.fNet->getPeerSnapshotSyncNeeded(
                    s1.raftServer.get(), 3) );
+
+    // Snapshot sync context must also be cleaned up alongside the flag,
+    // so that late install_snapshot_response messages cannot rewind
+    // next_log_idx/matched_idx to a stale snapshot point.
+    // (The response handler at handle_snapshot_sync.cxx:342 drops
+    // responses when sync_ctx is null, so clearing it here is sufficient.)
+    CHK_FALSE( s1.fNet->hasPeerSnapshotSyncCtx(
+                   s1.raftServer.get(), 3) );
+
+    // S3 must NOT have received an out_of_log_range warning — it was
+    // in range the whole time; only the stale snapshot_sync flag was wrong.
+    CHK_FALSE( s3.fNet->isServerOutOfLogRange(s3.raftServer.get()) );
 
     // S3's log index should be unchanged (no rollback).
     CHK_EQ( s3_log_idx, s3.raftServer->get_last_log_idx() );

--- a/tests/unit/snapshot_test.cxx
+++ b/tests/unit/snapshot_test.cxx
@@ -823,6 +823,137 @@ int snapshot_leader_switch_test() {
     return 0;
 }
 
+// Regression test for incident #1479: stale snapshot_sync_is_needed flag
+// when peer has advanced past the leader's snapshot.
+//
+// Production scenario: TOCTOU race between KeeperStateMachine's
+// latest_snapshot_meta and NuRaft's last_snapshot_ causes
+// is_snapshot_sync_needed to remain true while the peer's log
+// has advanced past the snapshot. The old code called system_exit
+// (abort); the fix clears the flag and falls through to normal
+// replication or OOL handling.
+//
+// This test uses the raft_server_handler test helper to directly
+// set the flag, since the TOCTOU race cannot be reproduced
+// deterministically in the fake network framework.
+int snapshot_stale_sync_flag_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( launch_servers( pkgs ) );
+    CHK_Z( make_group( pkgs ) );
+
+    // Append a message using separate thread.
+    ExecArgs exec_args(&s1);
+    TestSuite::ThreadHolder hh(&exec_args, fake_executer, fake_executer_killer);
+
+    for (auto& entry: pkgs) {
+        RaftPkg* pp = entry;
+        raft_params param = pp->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        param.snapshot_distance_ = 5;
+        pp->raftServer->update_params(param);
+    }
+
+    const size_t NUM = 10;
+
+    // Append messages asynchronously.
+    std::list< ptr< cmd_result< ptr<buffer> > > > handlers;
+    for (size_t ii = 0; ii < NUM; ++ii) {
+        std::string test_msg = "test" + std::to_string(ii);
+        ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+        msg->put(test_msg);
+        ptr< cmd_result< ptr<buffer> > > ret =
+            s1.raftServer->append_entries( {msg} );
+
+        CHK_TRUE( ret->get_accepted() );
+        handlers.push_back(ret);
+    }
+
+    // Replicate to both S2 and S3.
+    for (int ii = 0; ii < 4; ++ii) {
+        s1.fNet->execReqResp();
+        s1.fNet->execReqResp();
+        CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    }
+
+    // All servers should be in sync now with snapshot at ~index 10.
+    CHK_OK( s2.getTestSm()->isSame( *s1.getTestSm() ) );
+    CHK_OK( s3.getTestSm()->isSame( *s1.getTestSm() ) );
+
+    uint64_t s3_log_idx = s3.raftServer->get_last_log_idx();
+
+    // --- Simulate the TOCTOU race condition ---
+    // Force-set is_snapshot_sync_needed on the leader's peer for S3.
+    // In production, this flag gets set via RECEIVING_SNAPSHOT response,
+    // and becomes stale when the peer advances past the snapshot due to
+    // election churn or concurrent snapshot installs.
+    s1.fNet->setPeerSnapshotSyncNeeded(s1.raftServer.get(), 3, true);
+    CHK_TRUE( s1.fNet->getPeerSnapshotSyncNeeded(
+                  s1.raftServer.get(), 3) );
+
+    // Trigger heartbeat. With the old code, create_append_entries_req would
+    // enter create_sync_snapshot_req and call system_exit (abort) because
+    // peer's last_log_idx >= snapshot's last_log_idx.
+    // With the fix (Fix 2), the flag is cleared and the function falls
+    // through to normal replication or OOL handling.
+    s1.fTimer->invoke( timer_task_type::heartbeat_timer );
+    s1.fNet->execReqResp();
+    s1.fNet->execReqResp();
+
+    // The flag should now be cleared by Fix 2.
+    CHK_FALSE( s1.fNet->getPeerSnapshotSyncNeeded(
+                   s1.raftServer.get(), 3) );
+
+    // S3's log index should be unchanged (no rollback).
+    CHK_EQ( s3_log_idx, s3.raftServer->get_last_log_idx() );
+
+    // Append one more log and verify normal replication works.
+    for (size_t ii = NUM; ii < NUM + 1; ++ii) {
+        std::string test_msg = "test" + std::to_string(ii);
+        ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+        msg->put(test_msg);
+        ptr< cmd_result< ptr<buffer> > > ret =
+            s1.raftServer->append_entries( {msg} );
+
+        CHK_TRUE( ret->get_accepted() );
+        handlers.push_back(ret);
+    }
+    s1.fNet->execReqResp(); // replication.
+    s1.fNet->execReqResp(); // commit.
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+
+    // State machines should be identical after normal replication.
+    CHK_OK( s2.getTestSm()->isSame( *s1.getTestSm() ) );
+    CHK_OK( s3.getTestSm()->isSame( *s1.getTestSm() ) );
+
+    // There shouldn't be any open snapshot ctx.
+    CHK_Z( s1.getTestSm()->getNumOpenedUserCtxs() );
+
+    print_stats(pkgs);
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+
+    fake_executer_killer(&exec_args);
+    hh.join();
+    CHK_Z( hh.getResult() );
+
+    f_base->destroy();
+
+    return 0;
+}
+
 } // namespace snapshot_test
 using namespace snapshot_test;
 
@@ -857,6 +988,9 @@ int main(int argc, char* argv[]) {
 
     ts.doTest( "snapshot leader switch test",
                snapshot_leader_switch_test );
+
+    ts.doTest( "snapshot stale sync flag test",
+               snapshot_stale_sync_flag_test );
 
 #ifdef ENABLE_RAFT_STATS
     _msg("raft stats: ENABLED\n");

--- a/tests/unit/snapshot_test.cxx
+++ b/tests/unit/snapshot_test.cxx
@@ -936,7 +936,7 @@ int snapshot_stale_sync_flag_test() {
     // Snapshot sync context must also be cleaned up alongside the flag,
     // so that late install_snapshot_response messages cannot rewind
     // next_log_idx/matched_idx to a stale snapshot point.
-    // (The response handler at handle_snapshot_sync.cxx:342 drops
+    // (The response handler in handle_install_snapshot_resp drops
     // responses when sync_ctx is null, so clearing it here is sufficient.)
     CHK_FALSE( s1.fNet->hasPeerSnapshotSyncCtx(
                    s1.raftServer.get(), 3) );


### PR DESCRIPTION
## Summary
  - Fix a TOCTOU race where a stale `is_snapshot_sync_needed` flag causes the leader to call `system_exit` (abort) when the peer has already advanced past the leader's
  snapshot
  - In `create_append_entries_req`, detect when the peer's log index is at or past the snapshot and clear the flag instead of entering snapshot sync
  - In `create_sync_snapshot_req`, replace the fatal `system_exit` with graceful recovery: clear sync state and let the next heartbeat re-evaluate
  - Handle null snapshot case separately with a retry instead of abort