### PR TITLE
Reconnect rpc client if needed in `request_leadership`

### DIFF
--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -268,6 +268,11 @@ public:
     bool recreate_rpc(ptr<srv_config>& config,
                       context& ctx);
 
+    void reset_rpc() {
+        std::lock_guard<std::mutex> l(rpc_protector_);
+        rpc_.reset();
+    }
+
     void reset_rpc_errs()   { rpc_errs_ = 0; }
     void inc_rpc_errs()     { rpc_errs_.fetch_add(1); }
     int32 get_rpc_errs()    { return rpc_errs_; }

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1459,8 +1459,37 @@ bool raft_server::request_leadership(int successor_id) {
         auto resp = process_req(*req, req_ext_params());
         return resp->get_result_code() == cmd_result_code::OK;
     } else {
-        auto result = send_msg_to_leader(req);
-        return result->get_result_code() == cmd_result_code::OK;
+        recur_lock(lock_);
+        auto entry = peers_.find(leader_);
+        if (entry == peers_.end()) {
+            p_er("cannot request leadership: cannot find peer for "
+                 "leader id %d", leader_.load());
+            return false;
+        }
+
+        ptr<peer> pp = entry->second;
+        if (pp->make_busy()) {
+            if (pp->need_to_reconnect())
+            {
+                p_in("need to reconnet to peer %d", leader_.load());
+                if (ptr<srv_config> s_conf = get_config()->get_server(leader_))
+                {
+                    p_in("reconnecting to peer %d", leader_.load());
+                    pp->recreate_rpc(s_conf, *ctx_);
+                }
+                else
+                {
+                    p_in("can't reconnect to peer %d because configuration was not found", leader_.load());
+                }
+            }
+
+            p_in("requesting leadership from leader %d", leader_.load());
+            pp->send_req(pp, req, resp_handler_);
+            return true;
+        } else {
+            p_in("cannot request leadership, leader is busy");
+            return false;
+        }
     }
 }
 

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1459,22 +1459,8 @@ bool raft_server::request_leadership(int successor_id) {
         auto resp = process_req(*req, req_ext_params());
         return resp->get_result_code() == cmd_result_code::OK;
     } else {
-        recur_lock(lock_);
-        auto entry = peers_.find(leader_);
-        if (entry == peers_.end()) {
-            p_er("cannot request leadership: cannot find peer for "
-                 "leader id %d", leader_.load());
-            return false;
-        }
-        ptr<peer> pp = entry->second;
-        if (pp->make_busy()) {
-            p_in("requesting leadership from leader %d", leader_.load());
-            pp->send_req(pp, req, resp_handler_);
-            return true;
-        } else {
-            p_in("cannot request leadership, leader is busy");
-            return false;
-        }
+        auto result = send_msg_to_leader(req);
+        return result->get_result_code() == cmd_result_code::OK;
     }
 }
 

--- a/tests/unit/fake_network.hxx
+++ b/tests/unit/fake_network.hxx
@@ -94,6 +94,14 @@ public:
 
     void goesOnline() { online =  true; }
 
+    void dropPeerConnection(raft_server* srv, int peer_id) {
+        auto& peers = get_peers(srv);
+        auto entry = peers.find(peer_id);
+        if (entry != peers.end()) {
+            entry->second->reset_rpc();
+        }
+    }
+
     bool isOnline() const { return online; }
 
     void stop();

--- a/tests/unit/leader_election_test.cxx
+++ b/tests/unit/leader_election_test.cxx
@@ -687,9 +687,36 @@ int leadership_takeover_by_request_test() {
     // Wait for bg commit for configuration change.
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
-    CHK_FALSE( s1.raftServer->is_leader() );
-    CHK_TRUE( s2.raftServer->is_leader() );
-    CHK_FALSE( s3.raftServer->is_leader() );
+    CHK_EQ( 2, s1.raftServer->get_leader() );
+    CHK_EQ( 2, s2.raftServer->get_leader() );
+    CHK_EQ( 2, s3.raftServer->get_leader() );
+
+    // Drop S3's RPC connection to leader S2 to test reconnection
+    // in request_leadership.
+    s3.dbgLog(" --- request leadership forwarding with dropped connection ---");
+    s3.dropPeerConnection(2);
+    CHK_TRUE( s3.raftServer->request_leadership(1) );
+    s3.fNet->execReqResp();
+
+    s1.fNet->execReqResp();
+
+    s2.fTimer->invoke( timer_task_type::heartbeat_timer );
+    s2.fNet->execReqResp();
+    s2.fNet->execReqResp();
+
+    s1.fNet->execReqResp();
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+
+    // Send new config as a new leader.
+    s1.fNet->execReqResp();
+    // Follow-up: commit.
+    s1.fNet->execReqResp();
+    // Wait for bg commit for configuration change.
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+
+    CHK_EQ( 1, s1.raftServer->get_leader() );
+    CHK_EQ( 1, s2.raftServer->get_leader() );
+    CHK_EQ( 1, s3.raftServer->get_leader() );
 
     print_stats(pkgs);
 

--- a/tests/unit/raft_package_fake.hxx
+++ b/tests/unit/raft_package_fake.hxx
@@ -152,6 +152,10 @@ public:
         _s_info(ll) << msg;
     }
 
+    void dropPeerConnection(int peer_id) {
+        fNet->dropPeerConnection(raftServer.get(), peer_id);
+    }
+
     int myId;
     std::string myEndpoint;
     ptr<FakeNetworkBase> fBase;

--- a/tests/unit/raft_server_test.cxx
+++ b/tests/unit/raft_server_test.cxx
@@ -909,6 +909,15 @@ int priority_v2_test() {
     CHK_Z( launch_servers( pkgs ) );
     CHK_Z( make_group( pkgs ) );
 
+    for (auto& pp: pkgs) {
+        raft_params param = pp->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        param.auto_forwarding_ = true;
+        pp->raftServer->update_params(param);
+    }
+
+    CHK_Z( check_priorities(pkgs, {50, 50, 50}) );
+
     // Set the priority of S2 to 100.
     CHK_TRUE( s1.raftServer->set_priority_v2(2, 100) );
     // Send priority change reqs.
@@ -916,59 +925,49 @@ int priority_v2_test() {
     // Send reqs again for commit.
     s1.fNet->execReqResp();
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    CHK_Z( check_priorities(pkgs, {50, 100, 50}) );
 
     // Set the priority of S3 to 50.
-    CHK_TRUE( s1.raftServer->set_priority_v2(3, 50) );
+    CHK_TRUE( s1.raftServer->set_priority_v2(3, 42) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
     s1.fNet->execReqResp();
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    CHK_Z( check_priorities(pkgs, {50, 100, 42}) );
 
-    // Trigger election timer of S2.
-    s2.dbgLog(" --- invoke election timer of S2 ---");
-    s2.fTimer->invoke( timer_task_type::election_timer );
-    // Send pre-vote requests, and probably rejected by S1 and S3.
-    s2.fNet->execReqResp();
+    // Send HeartBeat to force is_leader_alive on all peers
+    s1.fTimer->invoke( timer_task_type::heartbeat_timer );
+    s1.fNet->execReqResp();
 
-    // Trigger election timer of S3.
-    s3.dbgLog(" --- invoke election timer of S3 ---");
-    // It will not initiate vote due to priority.
-    s3.fTimer->invoke( timer_task_type::election_timer );
-
-    // Trigger election timer of S3 again.
-    s3.dbgLog(" --- invoke election timer of S3 ---");
-    // Now it will initiate vote by help of priority decay.
-    s3.fTimer->invoke( timer_task_type::election_timer );
-
-    // Send pre-vote requests, it will be rejected by S1, accepted by S2.
-    // As a part of resp handling, it will initiate vote request.
-    s3.fNet->execReqResp();
-    // Send vote requests, S2 will deny due to priority.
-    s3.fNet->execReqResp();
-
-    // S1 should be still leader.
     CHK_TRUE( s1.raftServer->is_leader() );
     CHK_FALSE( s2.raftServer->is_leader() );
     CHK_FALSE( s3.raftServer->is_leader() );
-
     CHK_TRUE( s1.raftServer->is_leader_alive() );
-    CHK_FALSE( s2.raftServer->is_leader_alive() );
-    CHK_FALSE( s3.raftServer->is_leader_alive() );
+    CHK_TRUE( s2.raftServer->is_leader_alive() );
+    CHK_TRUE( s3.raftServer->is_leader_alive() );
 
     // Follower to leader broadcast
-    CHK_TRUE( s2.raftServer->set_priority_v2(1, 101) );
+    CHK_FALSE( s2.raftServer->set_priority_v2(1, 101) );
+    // Forward set priority change request
     s2.fNet->execReqResp();
-    CHK_Z( check_priorities(pkgs, {101, 100, 50}) );
-
-    CHK_TRUE( s3.raftServer->set_priority_v2(2, 102) );
-    s3.fNet->execReqResp();
-    CHK_Z( check_priorities(pkgs, {101, 102, 50}) );
+    // Send priority change reqs.
+    s1.fNet->execReqResp();
+    // Send reqs again for commit.
+    s1.fNet->execReqResp();
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    CHK_Z( check_priorities(pkgs, {101, 100, 42}) );
 
     // Follower to self broadcast
-    CHK_TRUE( s3.raftServer->set_priority_v2(3, 103) );
+    CHK_FALSE( s3.raftServer->set_priority_v2(3, 103) );
+    // Forward set priority change request
     s3.fNet->execReqResp();
-    CHK_Z( check_priorities(pkgs, {101, 102, 103}) );
+    // Send priority change reqs.
+    s1.fNet->execReqResp();
+    // Send reqs again for commit.
+    s1.fNet->execReqResp();
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    CHK_Z( check_priorities(pkgs, {101, 100, 103}) );
 
     print_stats(pkgs);
 
@@ -2126,6 +2125,9 @@ int main(int argc, char** argv) {
 
     ts.doTest( "extended append_entries API test",
                extended_append_entries_api_test );
+
+    ts.doTest( "priority v2 test",
+               priority_v2_test );
 
 #ifdef ENABLE_RAFT_STATS
     _msg("raft stats: ENABLED\n");


### PR DESCRIPTION
If `request_leadership` is proxied to the leader to make the other node a leader, and the RPC channel between the initiator and the leader is not active (probably due to a network error), we need to reconnect; otherwise, reconfiguration will be a no-op.