### PR TITLE
Fix request_leadership to reconnect before acquiring busy lock

### DIFF
--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1468,21 +1468,21 @@ bool raft_server::request_leadership(int successor_id) {
         }
 
         ptr<peer> pp = entry->second;
-        if (pp->make_busy()) {
-            if (pp->need_to_reconnect())
-            {
-                p_in("need to reconnet to peer %d", leader_.load());
-                if (ptr<srv_config> s_conf = get_config()->get_server(leader_))
-                {
-                    p_in("reconnecting to peer %d", leader_.load());
-                    pp->recreate_rpc(s_conf, *ctx_);
-                }
-                else
-                {
-                    p_in("can't reconnect to peer %d because configuration was not found", leader_.load());
-                }
+        if (pp->need_to_reconnect()) {
+            p_in("need to reconnect to peer %d", leader_.load());
+            ptr<srv_config> s_conf = get_config()->get_server(leader_);
+            if (!s_conf) {
+                p_wn("can't reconnect to peer %d: config not found",
+                     leader_.load());
+                return false;
             }
+            if (!pp->recreate_rpc(s_conf, *ctx_)) {
+                p_wn("reconnection to peer %d failed", leader_.load());
+                return false;
+            }
+        }
 
+        if (pp->make_busy()) {
             p_in("requesting leadership from leader %d", leader_.load());
             pp->send_req(pp, req, resp_handler_);
             return true;


### PR DESCRIPTION
Move the reconnection check before make_busy() so that a stale connection is re-established before we attempt to send the leadership request. Return early on reconnection failure instead of silently proceeding with a broken RPC.

