### PR TITLE
Actually async log appending on follower

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -34,6 +34,7 @@ limitations under the License.
 #include "thread.hxx"
 
 #include <list>
+#include <deque>
 #include <map>
 #include <mutex>
 #include <string>
@@ -1696,6 +1697,21 @@ protected:
      *          awaiter at a time, by the help of `lock_`.
      */
     EventAwaiter* ea_follower_log_append_;
+
+    /**
+     * Used when `raft_params::parallel_log_appending_` and streaming mode
+     * are both enabled. Instead of blocking in `handle_append_entries` waiting
+     * for log durability, the follower defers the response and queues a promise
+     * here. `notify_log_append_completion` fulfills promises once entries
+     * become durable, which triggers the ASIO layer to send the response.
+     */
+    struct pending_follower_resp
+    {
+        ulong last_entry_idx;
+        ulong last_entry_term;
+        ptr<cmd_result<ptr<buffer>>> promise;
+    };
+    std::deque<pending_follower_resp> pending_follower_resps_;
 
     /**
      * If `true`, test mode is enabled.

--- a/include/libnuraft/resp_msg.hxx
+++ b/include/libnuraft/resp_msg.hxx
@@ -83,6 +83,11 @@ public:
         accepted_ = true;
     }
 
+    void unaccept() {
+        next_idx_ = 0;
+        accepted_ = false;
+    }
+
     void set_ctx(ptr<buffer> src) {
         ctx_ = std::move(src);
     }

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -522,16 +522,18 @@ public:
     }
 
 private:
-    // Call only from send side (otherwise data race on pipelined_).
+    // Call only from receive side (otherwise data race on pipelined_).
     void request_stop() {
         if (pipelined_) {
             // Don't stop yet, let pending response writes drain.
             // (Can't stop right here even if we wanted to: another
             //  thread may be calling stop() right now after failing to send resp.)
-            std::lock_guard<std::mutex> guard(pending_resps_lock_);
+            std::unique_lock<std::mutex> guard(pending_resps_lock_);
             stop_after_sending_resps_ = true;
             if (!writing_resp_ && pending_resps_.empty()) {
+                guard.unlock();
                 this->stop();
+                return;
             }
         } else {
             this->stop();
@@ -1016,13 +1018,14 @@ private:
     void try_send_pending_resps(ptr<rpc_session> self) {
         ptr<pending_resp_entry> entry;
         {
-            std::lock_guard<std::mutex> guard(pending_resps_lock_);
+            std::unique_lock<std::mutex> guard(pending_resps_lock_);
             if (writing_resp_) return;
             if (pending_resps_.empty() ||
                 !pending_resps_.front()->ready.load(
                     std::memory_order_acquire))
             {
                 if (stop_after_sending_resps_ && pending_resps_.empty()) {
+                    guard.unlock();
                     this->stop();
                 }
                 return;

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -497,7 +497,7 @@ public:
     }
 
     void stop() {
-        std::lock_guard lock(stop_mutex_);
+        std::lock_guard<std::mutex> lock(stop_mutex_);
         if (!handler_) // already stopped
             return;
 
@@ -516,7 +516,7 @@ public:
         }
 
         {
-            std::lock_guard lock(handler_mutex_);
+            std::lock_guard<std::mutex> lock(handler_mutex_);
             handler_.reset();
         }
     }
@@ -647,7 +647,7 @@ private:
 
         ptr<msg_handler> handler;
         {
-            std::lock_guard lock(handler_mutex_);
+            std::lock_guard<std::mutex> lock(handler_mutex_);
             handler = handler_;
         }
         if (!handler)
@@ -1596,10 +1596,10 @@ public:
 
         for (auto& entry: req->log_entries()) {
             ptr<log_entry>& le = entry;
-            auto& le_buf = le->get_buf();
             ptr<buffer> entry_buf = buffer::alloc
                                     ( LOG_ENTRY_SIZE + le->get_buf().size() );
 #if 0
+            auto& le_buf = le->get_buf();
             entry_buf->put( le->get_term() );
             entry_buf->put( (byte)le->get_val_type() );
             entry_buf->put( (int32)le_buf.size() );

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -358,7 +358,7 @@ public:
                          err.value(),
                          err.message().c_str());
                 }
-                this->stop();
+                this->request_stop();
             });
         }
     }
@@ -379,16 +379,7 @@ public:
                       err.value(),
                       err.message().c_str(),
                       self.use_count() );
-                if (pipelined_) {
-                    // Don't stop yet — let pending response writes drain.
-                    std::lock_guard<std::mutex> guard(pending_resps_lock_);
-                    read_failed_ = true;
-                    if (!writing_resp_ && pending_resps_.empty()) {
-                        this->stop();
-                    }
-                    return;
-                }
-                this->stop();
+                this->request_stop();
                 return;
             }
 
@@ -428,7 +419,7 @@ public:
                     impl_->get_options().corrupted_msg_handler_(header_, nullptr);
                 }
 
-                this->stop();
+                this->request_stop();
                 return;
             }
 
@@ -444,7 +435,7 @@ public:
                     impl_->get_options().corrupted_msg_handler_(header_, nullptr);
                 }
 
-                this->stop();
+                this->request_stop();
                 return;
             }
 
@@ -456,7 +447,7 @@ public:
                     impl_->get_options().corrupted_msg_handler_(header_, nullptr);
                 }
 
-                this->stop();
+                this->request_stop();
                 return;
             }
 
@@ -474,7 +465,7 @@ public:
                     impl_->get_options().corrupted_msg_handler_(header_, nullptr);
                 }
 
-                this->stop();
+                this->request_stop();
                 return;
             }
             // Warning for 1GB+
@@ -501,22 +492,54 @@ public:
         } );
     }
 
-    void stop() {
-        invoke_connection_callback(false);
-        close_socket();
-        if (callback_) {
-            callback_(this->shared_from_this());
-        }
-        handler_.reset();
-    }
-
     ssl_socket::lowest_layer_type& socket() {
         return ssl_socket_.lowest_layer();
     }
 
+    void stop() {
+        std::lock_guard lock(stop_mutex_);
+        if (!handler_) // already stopped
+            return;
+
+        invoke_connection_callback(false, handler_);
+
+        // Cancel the socket to interrupt async operations in hopes of making shutdown faster.
+        // But maybe this would cause the mysterious MONSTOR-9378
+        // problem that close_socket() alludes to?
+        if (socket().is_open()) {
+            socket_.cancel();
+        }
+
+        close_socket();
+        if (callback_) {
+            callback_(this->shared_from_this());
+        }
+
+        {
+            std::lock_guard lock(handler_mutex_);
+            handler_.reset();
+        }
+    }
+
 private:
-    void invoke_connection_callback(bool is_open) {
-        if (is_leader_ && src_id_ != handler_->get_leader()) {
+    // Call only from send side (otherwise data race on pipelined_).
+    void request_stop() {
+        if (pipelined_) {
+            // Don't stop yet, let pending response writes drain.
+            // (Can't stop right here even if we wanted to: another
+            //  thread may be calling stop() right now after failing to send resp.)
+            std::lock_guard<std::mutex> guard(pending_resps_lock_);
+            stop_after_sending_resps_ = true;
+            if (!writing_resp_ && pending_resps_.empty()) {
+                this->stop();
+            }
+        } else {
+            this->stop();
+        }
+    }
+
+    void invoke_connection_callback(bool is_open, ptr<msg_handler> handler) {
+        if (is_leader_ && src_id_ != handler->get_leader()) {
             // Leader has been changed without closing session.
             is_leader_ = false;
         }
@@ -527,11 +550,11 @@ private:
                   cached_port_,
                   src_id_,
                   is_leader_ );
-        cb_func::Param cb_param( handler_->get_id(),
-                                 handler_->get_leader(),
+        cb_func::Param cb_param( handler->get_id(),
+                                 handler->get_leader(),
                                  -1,
                                  &args );
-        handler_->invoke_callback
+        handler->invoke_callback
             ( is_open ? cb_func::ConnectionOpened : cb_func::ConnectionClosed,
               &cb_param );
     }
@@ -561,7 +584,7 @@ private:
                   session_id_,
                   err.value(),
                   err.message().c_str() );
-            this->stop();
+            this->request_stop();
         }
     }
 
@@ -617,18 +640,26 @@ private:
                     impl_->get_options().corrupted_msg_handler_(header_, log_ctx);
                 }
 
-                this->stop();
+                this->request_stop();
                 return;
             }
         }
+
+        ptr<msg_handler> handler;
+        {
+            std::lock_guard lock(handler_mutex_);
+            handler = handler_;
+        }
+        if (!handler)
+            return; // stop() was called
 
         if (src_id_ == -1) {
             // It means this is the first message on this session.
             // Invoke callback function of new connection.
             src_id_ = src;
-            invoke_connection_callback(true);
+            invoke_connection_callback(true, handler);
 
-        } else if (is_leader_ && src_id_ != handler_->get_leader()) {
+        } else if (is_leader_ && src_id_ != handler->get_leader()) {
             // Leader has been changed without closing session.
             is_leader_ = false;
         }
@@ -651,11 +682,11 @@ private:
                           cached_port_,
                           src_id_,
                           is_leader_ );
-                cb_func::Param cb_param( handler_->get_id(),
-                                         handler_->get_leader(),
+                cb_func::Param cb_param( handler->get_id(),
+                                         handler->get_leader(),
                                          -1,
                                          &args );
-                handler_->invoke_callback( cb_func::NewSessionFromLeader,
+                handler->invoke_callback( cb_func::NewSessionFromLeader,
                                            &cb_param );
             }
         }
@@ -699,7 +730,7 @@ private:
                         impl_->get_options().corrupted_msg_handler_(header_, log_ctx);
                     }
 
-                    this->stop();
+                    this->request_stop();
                     return;
                 }
                 ulong term = ss.get_u64();
@@ -719,7 +750,7 @@ private:
                         impl_->get_options().corrupted_msg_handler_(header_, log_ctx);
                     }
 
-                    this->stop();
+                    this->request_stop();
                     return;
                 }
 
@@ -741,7 +772,7 @@ private:
                             impl_->get_options().corrupted_msg_handler_(header_, log_ctx);
                         }
 
-                        this->stop();
+                        this->request_stop();
                         return;
                     }
                 }
@@ -757,16 +788,16 @@ private:
                impl_->get_options().invoke_req_cb_on_empty_meta_ ) ) {
             if ( !impl_->get_options().read_req_meta_
                   ( req_to_params(req.get(), nullptr), meta_str ) ) {
-                this->stop();
+                this->request_stop();
                 return;
             }
         }
 
         // === RAFT server processes the request here. ===
-        ptr<resp_msg> resp = raft_server_handler::process_req(handler_.get(), *req);
+        ptr<resp_msg> resp = raft_server_handler::process_req(handler.get(), *req);
         if (!resp) {
             p_wn("no response is returned from raft message handler");
-            this->stop();
+            this->request_stop();
             return;
         }
 
@@ -850,7 +881,7 @@ private:
               "due to error: %s",
               this->session_id_,
               ex.what() );
-        this->stop();
+        this->request_stop();
        }
     }
 
@@ -961,7 +992,7 @@ private:
                       "to error %d",
                       session_id_,
                       err_code.value() );
-                this->stop();
+                this->request_stop();
             }
         } );
 
@@ -970,7 +1001,7 @@ private:
               "due to error: %s",
               this->session_id_,
               ex.what() );
-        this->stop();
+        this->request_stop();
        }
     }
 
@@ -991,7 +1022,7 @@ private:
                 !pending_resps_.front()->ready.load(
                     std::memory_order_acquire))
             {
-                if (read_failed_ && pending_resps_.empty()) {
+                if (stop_after_sending_resps_ && pending_resps_.empty()) {
                     this->stop();
                 }
                 return;
@@ -1021,6 +1052,7 @@ private:
                       "to peer due to error %d",
                       session_id_,
                       err_code.value() );
+
                 this->stop();
             }
         } );
@@ -1088,6 +1120,9 @@ private:
      */
     std::mutex pending_resps_lock_;
 
+    std::mutex stop_mutex_;
+    std::mutex handler_mutex_;
+
     /**
      * True while an async write of a pipelined response is in progress.
      */
@@ -1096,14 +1131,20 @@ private:
     /**
      * True once we have entered pipelined mode on this session
      * (first async_cb response seen in streaming mode).
+     * In this state, there are two "threads" operating on this rpc_session:
+     *  * receive side: start <-> read_complete async loop,
+     *  * send side: try_send_pending_resps async loop.
+     * Be careful about thread safety, don't access the same fields
+     * from two sides without synchronization. Most fields belong exclusively
+     * to the send side, and the rest are protected by pending_resps_lock_.
+     * Only the send side can call stop(); receive side should call request_stop() instead.
      */
     bool pipelined_{false};
 
     /**
-     * True if the read side of this session has failed (EOF / error).
-     * We defer `stop()` until all pending writes have drained.
+     * True if we should close the connection after pending_resps_ is drained.
      */
-    bool read_failed_{false};
+    bool stop_after_sending_resps_{false};
 };
 
 // rpc listener implementation

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -59,6 +59,7 @@ limitations under the License.
 #include <ctime>
 #include <exception>
 #include <ios>
+#include <deque>
 #include <list>
 #include <thread>
 #include <string>
@@ -378,6 +379,15 @@ public:
                       err.value(),
                       err.message().c_str(),
                       self.use_count() );
+                if (pipelined_) {
+                    // Don't stop yet — let pending response writes drain.
+                    std::lock_guard<std::mutex> guard(pending_resps_lock_);
+                    read_failed_ = true;
+                    if (!writing_resp_ && pending_resps_.empty()) {
+                        this->stop();
+                    }
+                    return;
+                }
                 this->stop();
                 return;
             }
@@ -552,6 +562,17 @@ private:
                   err.value(),
                   err.message().c_str() );
             this->stop();
+        }
+    }
+
+    static void update_resp_with_async_result(resp_msg* resp,
+                                              cmd_result<ptr<buffer>, ptr<std::exception>>& res,
+                                              ptr<std::exception>& ) {
+        resp->set_ctx(res.get());
+        cmd_result_code code = res.get_result_code();
+        if (code != cmd_result_code::OK) {
+            resp->unaccept();
+            resp->set_result_code(code);
         }
     }
 
@@ -749,7 +770,55 @@ private:
             return;
         }
 
-        if (resp->has_async_cb()) {
+        if (!pipelined_ && (resp->has_async_cb() && impl_->get_options().streaming_mode_)) {
+            pipelined_ = true;
+        }
+
+        if (pipelined_) {
+            // Pipelined mode: queue the deferred response and immediately
+            // read the next request. The response will be sent when the
+            // async result is ready (e.g. for append_entries request we
+            // send response after log store fsync, which may take a while).
+
+            if (resp->has_cb())
+                resp = resp->call_cb(resp);
+
+            auto entry = cs_new<pending_resp_entry>();
+            entry->req = req;
+            entry->resp = resp;
+
+            {
+                std::lock_guard<std::mutex> guard(pending_resps_lock_);
+                pending_resps_.push_back(entry);
+            }
+
+            if (resp->has_async_cb()) {
+                ptr< cmd_result< ptr<buffer> > > ret = resp->call_async_cb();
+                ret->when_ready(
+                    [this, self, entry]
+                    ( cmd_result<ptr<buffer>, ptr<std::exception>>& res,
+                      ptr<std::exception>& exp ) {
+                        // Note: the async part of request processing currently has the power
+                        // to fail the request (by setting non-ok result code in `res`),
+                        // but can't change other fields of resp_msg, e.g. `next_idx`.
+                        // This is an unnecessary limitation, but it's ok for
+                        // the current user of this feature (parallel log appending
+                        // on follower).
+                        update_resp_with_async_result(entry->resp.get(), res, exp);
+                        entry->ready.store(true, std::memory_order_release);
+                        try_send_pending_resps(self);
+                        res.reset();
+                    }
+                );
+            } else {
+                entry->ready.store(true, std::memory_order_release);
+                try_send_pending_resps(self);
+            }
+
+            // Receive next message.
+            this->start(self);
+
+        } else if (resp->has_async_cb()) {
             // Response will be ready later, setup a callback function
             // (only for auto-forwarding with `client_request` type
             //  in async handling mode).
@@ -760,7 +829,7 @@ private:
                 [this, self, req, resp]
                 ( cmd_result<ptr<buffer>, ptr<std::exception>>& res,
                   ptr<std::exception>& exp ) {
-                    resp->set_ctx(res.get());
+                    update_resp_with_async_result(resp.get(), res, exp);
                     on_resp_ready(req, resp);
                     // This is needed to avoid circular reference.
                     res.reset();
@@ -785,10 +854,7 @@ private:
        }
     }
 
-    void on_resp_ready(ptr<req_msg> req, ptr<resp_msg> resp) {
-        ptr<rpc_session> self = this->shared_from_this();
-
-       try {
+    ptr<buffer> serialize_resp(ptr<req_msg>& req, ptr<resp_msg>& resp) {
         ptr<buffer> resp_ctx = resp->get_ctx();
         int32 resp_ctx_size = (resp_ctx) ? resp_ctx->size() : 0;
         int32 result_code_size = sizeof(int32_t);
@@ -872,6 +938,15 @@ private:
             bs.put_i32(resp->get_result_code());
         }
 
+        return resp_buf;
+    }
+
+    void on_resp_ready(ptr<req_msg> req, ptr<resp_msg> resp) {
+        ptr<rpc_session> self = this->shared_from_this();
+
+       try {
+        ptr<buffer> resp_buf = serialize_resp(req, resp);
+
         aa::write( ssl_enabled_, ssl_socket_, socket_,
                    asio::buffer(resp_buf->data_begin(), resp_buf->size()),
                    [this, self, resp_buf]
@@ -892,6 +967,66 @@ private:
 
        } catch (std::exception& ex) {
         p_er( "session %" PRIu64 " failed to process request message "
+              "due to error: %s",
+              this->session_id_,
+              ex.what() );
+        this->stop();
+       }
+    }
+
+    // --- Pipelined response support (streaming mode) ---
+
+    struct pending_resp_entry {
+        ptr<req_msg> req;
+        ptr<resp_msg> resp;
+        std::atomic<bool> ready{false};
+    };
+
+    void try_send_pending_resps(ptr<rpc_session> self) {
+        ptr<pending_resp_entry> entry;
+        {
+            std::lock_guard<std::mutex> guard(pending_resps_lock_);
+            if (writing_resp_) return;
+            if (pending_resps_.empty() ||
+                !pending_resps_.front()->ready.load(
+                    std::memory_order_acquire))
+            {
+                if (read_failed_ && pending_resps_.empty()) {
+                    this->stop();
+                }
+                return;
+            }
+            writing_resp_ = true;
+            entry = pending_resps_.front();
+            pending_resps_.pop_front();
+        }
+
+       try {
+        ptr<buffer> resp_buf = serialize_resp(entry->req, entry->resp);
+
+        aa::write( ssl_enabled_, ssl_socket_, socket_,
+                   asio::buffer(resp_buf->data_begin(), resp_buf->size()),
+                   [this, self, resp_buf]
+                   (ERROR_CODE err_code, size_t) -> void
+        {
+            (void)resp_buf;
+            if (!err_code) {
+                {
+                    std::lock_guard<std::mutex> guard(pending_resps_lock_);
+                    writing_resp_ = false;
+                }
+                try_send_pending_resps(self);
+            } else {
+                p_er( "session %" PRIu64 " failed to send pipelined response "
+                      "to peer due to error %d",
+                      session_id_,
+                      err_code.value() );
+                this->stop();
+            }
+        } );
+
+       } catch (std::exception& ex) {
+        p_er( "session %" PRIu64 " failed to send pipelined response "
               "due to error: %s",
               this->session_id_,
               ex.what() );
@@ -938,6 +1073,37 @@ private:
      * CRC number from the request header.
      */
     uint32_t crc_from_msg_;
+
+    // --- Pipelined response state (streaming mode) ---
+
+    /**
+     * Queue of pending responses waiting to be sent.
+     * In pipelined mode, responses are sent in FIFO order;
+     * async responses wait until their result is ready.
+     */
+    std::deque<ptr<pending_resp_entry>> pending_resps_;
+
+    /**
+     * Lock protecting `pending_resps_`, `writing_resp_`, and `read_failed_`.
+     */
+    std::mutex pending_resps_lock_;
+
+    /**
+     * True while an async write of a pipelined response is in progress.
+     */
+    bool writing_resp_{false};
+
+    /**
+     * True once we have entered pipelined mode on this session
+     * (first async_cb response seen in streaming mode).
+     */
+    bool pipelined_{false};
+
+    /**
+     * True if the read side of this session has failed (EOF / error).
+     * We defer `stop()` until all pending writes have drained.
+     */
+    bool read_failed_{false};
 };
 
 // rpc listener implementation

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -1031,7 +1031,7 @@ private:
                 return;
             }
             writing_resp_ = true;
-            entry = pending_resps_.front();
+            entry = std::move(pending_resps_.front());
             pending_resps_.pop_front();
         }
 
@@ -1119,7 +1119,7 @@ private:
     std::deque<ptr<pending_resp_entry>> pending_resps_;
 
     /**
-     * Lock protecting `pending_resps_`, `writing_resp_`, and `read_failed_`.
+     * Lock protecting `pending_resps_`, `writing_resp_`, and `stop_after_sending_resps_`.
      */
     std::mutex pending_resps_lock_;
 

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -684,6 +684,11 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,
 // Only makes sense when parallel_log_appending_ and max_log_gap_in_stream_ are both enabled;
 // otherwise either the log store or the asio handler would wait for durability anyway.
 static bool should_use_async_log_appending(const raft_params& params) {
+    // Note: the max_log_gap_in_stream_ check is just a heuristic;
+    // we're interested in the max_log_gap_in_stream_ *on the leader node*,
+    // not on this node. But typically parameters are the same on all nodes
+    // in practice, so this is ok.
+    // This function's return value doesn't affect correctness either way.
     return params.parallel_log_appending_ && params.max_log_gap_in_stream_ > 0;
 }
 
@@ -1646,11 +1651,9 @@ void raft_server::notify_log_append_completion(bool ok) {
                 uint64_t durable_idx = log_store_->last_durable_index();
                 ptr<buffer> empty_buf;
                 ptr<std::exception> no_err;
-                while ( !pending_follower_resps_.empty() ) {
+                while ( !pending_follower_resps_.empty() &&
+                        pending_follower_resps_.front().last_entry_idx <= durable_idx ) {
                     pending_follower_resp& entry = pending_follower_resps_.front();
-                    if (entry.last_entry_idx > durable_idx) {
-                        break;
-                    }
 
                     // Redundant check that the entries that became durable are the ones we wrote.
                     ulong term_in_log_store = log_store_->term_at(entry.last_entry_idx);

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -868,6 +868,9 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
     // Reset timer.
     last_rcvd_append_entries_req_.reset();
 
+    ptr<raft_params> params = ctx_->get_params();
+    bool async_log_appending = params->parallel_log_appending_ && params->max_log_gap_in_stream_ > 0;
+
     if (req.log_entries().size() > 0) {
         // Write logs to store, start from overlapped logs
 
@@ -1037,14 +1040,13 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
         log_store_->end_of_append_batch( req.get_last_log_idx() + 1,
                                          req.log_entries().size() );
 
-        ptr<raft_params> params = ctx_->get_params();
         if (params->parallel_log_appending_) {
             uint64_t last_durable_index = log_store_->last_durable_index();
             ulong required_durable =
                 req.get_last_log_idx() + req.log_entries().size();
 
             if (last_durable_index < required_durable) {
-                if (params->max_log_gap_in_stream_ > 0) {
+                if (async_log_appending) {
                     // Pipelined mode (streaming + parallel log appending):
                     // defer the response until entries become durable.
                     // Unblock this thread to allow processing more appends
@@ -1076,6 +1078,24 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
                     }
                 }
             }
+        }
+    } else if (async_log_appending) {
+        // Previous handle_append_entries calls may have appended some
+        // log entries without waiting for durability.
+        // We should wait for those entries to become durable before
+        // sending response with `next_log_idx = target_precommit_index + 1`,
+        // even if this request had no new entries.
+        uint64_t last_durable_index = log_store_->last_durable_index();
+        ulong required_durable =
+            req.get_last_log_idx() + req.log_entries().size();
+        if (last_durable_index < required_durable) {
+            p_ts( "durable index %" PRIu64 ", required %" PRIu64
+                    ", deferring response (pipelined)",
+                    last_durable_index, required_durable );
+            auto promise = cs_new<cmd_result<ptr<buffer>>>();
+            pending_follower_resps_.push_back(
+                {required_durable, /*last_entry_term=*/ 0, promise});
+            resp->set_async_cb([promise]() { return promise; });
         }
     }
 
@@ -1624,7 +1644,7 @@ void raft_server::notify_log_append_completion(bool ok) {
 
                     // Redundant check that the entries that became durable are the ones we wrote.
                     ulong term_in_log_store = log_store_->term_at(entry.last_entry_idx);
-                    if (term_in_log_store == entry.last_entry_term) {
+                    if (entry.last_entry_term == 0 || term_in_log_store == entry.last_entry_term) {
                         entry.promise->set_result(empty_buf, no_err, cmd_result_code::OK);
                     } else {
                         // This should be impossible because we clear pending_follower_resps_

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -916,6 +916,20 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
                   req.log_entries().size(),
                   cnt );
             rollback_in_progress = true;
+
+            // Fail any pending async append_entries requests: and entries they refer to
+            // are likely being rolled back, and leader term has changed.
+            if (!pending_follower_resps_.empty()) {
+                p_in( "rollback: discarding %zu pending pipelined responses",
+                      pending_follower_resps_.size() );
+                for (pending_follower_resp& resp: pending_follower_resps_) {
+                    ptr<buffer> empty_buf;
+                    ptr<std::exception> no_err;
+                    resp.promise->set_result(empty_buf, no_err, cmd_result_code::TERM_MISMATCH);
+                }
+                pending_follower_resps_.clear();
+            }
+
             // If rollback point is smaller than commit index,
             // should rollback commit index as well
             // (should not happen in Raft though).
@@ -1026,21 +1040,41 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
         ptr<raft_params> params = ctx_->get_params();
         if (params->parallel_log_appending_) {
             uint64_t last_durable_index = log_store_->last_durable_index();
-            while ( last_durable_index <
-                    req.get_last_log_idx() + req.log_entries().size() ) {
-                if (stopping_) return resp;
+            ulong required_durable =
+                req.get_last_log_idx() + req.log_entries().size();
 
-                // Some logs are not durable yet, wait here and block the thread.
-                p_ts( "durable index %" PRIu64
-                      ", sleep and wait for log appending completion",
-                      last_durable_index );
-                ea_follower_log_append_->wait_ms(params->heart_beat_interval_);
+            if (last_durable_index < required_durable) {
+                if (params->max_log_gap_in_stream_ > 0) {
+                    // Pipelined mode (streaming + parallel log appending):
+                    // defer the response until entries become durable.
+                    // Unblock this thread to allow processing more appends
+                    // while waiting for durability (typically fsync, slow).
+                    // `notify_log_append_completion` will fulfill the promise.
+                    p_ts( "durable index %" PRIu64 ", required %" PRIu64
+                          ", deferring response (pipelined)",
+                          last_durable_index, required_durable );
+                    auto promise = cs_new<cmd_result<ptr<buffer>>>();
+                    pending_follower_resps_.push_back(
+                        {required_durable, req.log_entries().back()->get_term(), promise});
+                    resp->set_async_cb([promise]() { return promise; });
 
-                // --- `notify_log_append_completion` API will wake it up. ---
+                } else {
+                    while ( last_durable_index < required_durable ) {
+                        if (stopping_) return resp;
 
-                ea_follower_log_append_->reset();
-                last_durable_index = log_store_->last_durable_index();
-                p_tr( "wake up, durable index %" PRIu64, last_durable_index );
+                        // Some logs are not durable yet, wait here and block the thread.
+                        p_ts( "durable index %" PRIu64
+                            ", sleep and wait for log appending completion",
+                            last_durable_index );
+                        ea_follower_log_append_->wait_ms(params->heart_beat_interval_);
+
+                        // --- `notify_log_append_completion` API will wake it up. ---
+
+                        ea_follower_log_append_->reset();
+                        last_durable_index = log_store_->last_durable_index();
+                        p_tr( "wake up, durable index %" PRIu64, last_durable_index );
+                    }
+                }
             }
         }
     }
@@ -1535,7 +1569,21 @@ ulong raft_server::get_expected_committed_log_idx() {
 }
 
 void raft_server::notify_log_append_completion(bool ok) {
-    if (stopping_) return;
+    if (stopping_) {
+        recur_lock(lock_);
+        // Send errors for pending async append_entries requests.
+        if (!pending_follower_resps_.empty()) {
+            p_in( "discarding %zu pending pipelined responses",
+                  pending_follower_resps_.size() );
+            for (pending_follower_resp& resp: pending_follower_resps_) {
+                ptr<buffer> empty_buf;
+                ptr<std::exception> no_err;
+                resp.promise->set_result(empty_buf, no_err, cmd_result_code::CANCELLED);
+            }
+            pending_follower_resps_.clear();
+        }
+        return;
+    }
 
     if (!ok) {
         // If log appending fails for follower, there is no way to proceed it.
@@ -1559,9 +1607,45 @@ void raft_server::notify_log_append_completion(bool ok) {
             request_append_entries_for_all();
         }
     } else {
+        ptr<raft_params> params = ctx_->get_params();
+        if (params->parallel_log_appending_ && params->max_log_gap_in_stream_ > 0) {
+            // Follower: send responses for async append_entries
+            // requests whose entries became durable.
+            recur_lock(lock_);
+            if (!pending_follower_resps_.empty()) {
+                uint64_t durable_idx = log_store_->last_durable_index();
+                ptr<buffer> empty_buf;
+                ptr<std::exception> no_err;
+                while ( !pending_follower_resps_.empty() ) {
+                    pending_follower_resp& entry = pending_follower_resps_.front();
+                    if (entry.last_entry_idx > durable_idx) {
+                        break;
+                    }
 
-        // Follower: wake up the waiting thread.
-        ea_follower_log_append_->invoke();
+                    // Redundant check that the entries that became durable are the ones we wrote.
+                    ulong term_in_log_store = log_store_->term_at(entry.last_entry_idx);
+                    if (term_in_log_store == entry.last_entry_term) {
+                        entry.promise->set_result(empty_buf, no_err, cmd_result_code::OK);
+                    } else {
+                        // This should be impossible because we clear pending_follower_resps_
+                        // when doing log_store_ rollback.
+                        p_er( "term mismatch in async append_entries: "
+                              "appended entry with idx %" PRIu64 " "
+                              "term %" PRIu64 ", durable entry has "
+                              "term %" PRIu64,
+                              entry.last_entry_idx,
+                              entry.last_entry_term,
+                              term_in_log_store);
+                        entry.promise->set_result(empty_buf, no_err, cmd_result_code::TERM_MISMATCH);
+                    }
+                    pending_follower_resps_.pop_front();
+                }
+            }
+        } else {
+            assert(pending_follower_resps_.empty());
+            // Follower: wake up the waiting thread.
+            ea_follower_log_append_->invoke();
+        }
     }
 }
 

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -677,6 +677,16 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,
     return req;
 }
 
+// Whether handle_append_entries should return a future that later
+// gets notified by notify_log_append_completion when log entries become durable.
+// This allows the leader to send multiple append_entries messages without waiting
+// for responses.
+// Only makes sense when parallel_log_appending_ and max_log_gap_in_stream_ are both enabled;
+// otherwise either the log store or the asio handler would wait for durability anyway.
+static bool should_use_async_log_appending(const raft_params& params) {
+    return params.parallel_log_appending_ && params.max_log_gap_in_stream_ > 0;
+}
+
 ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
 {
     bool supp_exp_warning = false;
@@ -869,7 +879,7 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
     last_rcvd_append_entries_req_.reset();
 
     ptr<raft_params> params = ctx_->get_params();
-    bool async_log_appending = params->parallel_log_appending_ && params->max_log_gap_in_stream_ > 0;
+    bool async_log_appending = should_use_async_log_appending(*params);
 
     if (req.log_entries().size() > 0) {
         // Write logs to store, start from overlapped logs
@@ -1628,7 +1638,7 @@ void raft_server::notify_log_append_completion(bool ok) {
         }
     } else {
         ptr<raft_params> params = ctx_->get_params();
-        if (params->parallel_log_appending_ && params->max_log_gap_in_stream_ > 0) {
+        if (should_use_async_log_appending(*params)) {
             // Follower: send responses for async append_entries
             // requests whose entries became durable.
             recur_lock(lock_);

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -935,7 +935,7 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
                   cnt );
             rollback_in_progress = true;
 
-            // Fail any pending async append_entries requests: and entries they refer to
+            // Fail any pending async append_entries requests: any entries they refer to
             // are likely being rolled back, and leader term has changed.
             if (!pending_follower_resps_.empty()) {
                 p_in( "rollback: discarding %zu pending pipelined responses",
@@ -1646,33 +1646,40 @@ void raft_server::notify_log_append_completion(bool ok) {
         if (should_use_async_log_appending(*params)) {
             // Follower: send responses for async append_entries
             // requests whose entries became durable.
-            recur_lock(lock_);
-            if (!pending_follower_resps_.empty()) {
-                uint64_t durable_idx = log_store_->last_durable_index();
-                ptr<buffer> empty_buf;
-                ptr<std::exception> no_err;
-                while ( !pending_follower_resps_.empty() &&
-                        pending_follower_resps_.front().last_entry_idx <= durable_idx ) {
-                    pending_follower_resp& entry = pending_follower_resps_.front();
+            std::vector<std::pair<ptr<cmd_result<ptr<buffer>>>, cmd_result_code>> resps;
+            {
+                recur_lock(lock_);
+                if (!pending_follower_resps_.empty()) {
+                    uint64_t durable_idx = log_store_->last_durable_index();
+                    while ( !pending_follower_resps_.empty() &&
+                            pending_follower_resps_.front().last_entry_idx <= durable_idx ) {
+                        pending_follower_resp& entry = pending_follower_resps_.front();
 
-                    // Redundant check that the entries that became durable are the ones we wrote.
-                    ulong term_in_log_store = log_store_->term_at(entry.last_entry_idx);
-                    if (entry.last_entry_term == 0 || term_in_log_store == entry.last_entry_term) {
-                        entry.promise->set_result(empty_buf, no_err, cmd_result_code::OK);
-                    } else {
-                        // This should be impossible because we clear pending_follower_resps_
-                        // when doing log_store_ rollback.
-                        p_er( "term mismatch in async append_entries: "
-                              "appended entry with idx %" PRIu64 " "
-                              "term %" PRIu64 ", durable entry has "
-                              "term %" PRIu64,
-                              entry.last_entry_idx,
-                              entry.last_entry_term,
-                              term_in_log_store);
-                        entry.promise->set_result(empty_buf, no_err, cmd_result_code::TERM_MISMATCH);
+                        // Redundant check that the entries that became durable are the ones we wrote.
+                        ulong term_in_log_store = log_store_->term_at(entry.last_entry_idx);
+                        if (entry.last_entry_term == 0 || term_in_log_store == entry.last_entry_term) {
+                            resps.emplace_back(std::move(entry.promise), cmd_result_code::OK);
+                        } else {
+                            // This should be impossible because we clear pending_follower_resps_
+                            // when doing log_store_ rollback.
+                            p_er( "term mismatch in async append_entries: "
+                                "appended entry with idx %" PRIu64 " "
+                                "term %" PRIu64 ", durable entry has "
+                                "term %" PRIu64,
+                                entry.last_entry_idx,
+                                entry.last_entry_term,
+                                term_in_log_store);
+                            resps.emplace_back(std::move(entry.promise), cmd_result_code::TERM_MISMATCH);
+                        }
+                        pending_follower_resps_.pop_front();
                     }
-                    pending_follower_resps_.pop_front();
                 }
+            }
+
+            ptr<buffer> empty_buf;
+            ptr<std::exception> no_err;
+            for (auto& p: resps) {
+                p.first->set_result(empty_buf, no_err, p.second);
             }
         } else {
             assert(pending_follower_resps_.empty());


### PR DESCRIPTION
Without this PR, follower does one fsync for each append_entries message (by waiting for log_store_->last_durable_index to advance in handle_append_entries). So it's sensitive to append_entries batching. If leader splits the same set of entries into two messages instead of one, we'll get two fsyncs instead of one. So leader faces a hard tradeoff: do more batching for fewer fsyncs or less batching for better pipelining (if there are two requests in flight, the recipient can start working on the second request immediately after finishing the first). And also follower couldn't do precommit and fsync in parallel - that's 2 out of 3 slowest operations being unnecessarily serialized with each other.

This PR allows the follower to keep receiving and processing more append_entries messages while waiting for fsync. Responses are sent when corresponding entries are fsynced. So while one fsync is in progress, multiple new append_entries messages can get processed and queued up for fsync. So the number of fsyncs mostly doesn't depend on append_entries batching, so enabling streaming mode (`nuraft_max_log_gap_in_stream) doesn't kill performance and actually improves it (by letting the follower do previous entry log write in parallel with next entry precommit).

(Half artisanally coded because claude didn't quite manage to do this correctly, but it was close. At first it seemed right; it took some effort to think through it properly, now I'm pretty sure I understand why this is correct.)