### PR TITLE
Fix stale RPC causing replication stall after snapshot sync

### DIFF
--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -52,6 +52,7 @@ public:
         , last_accepted_log_idx_(0)
         , next_batch_size_hint_in_bytes_(0)
         , matched_idx_(0)
+        , next_log_idx_floor_(0)
         , busy_flag_(false)
         , pending_commit_flag_(false)
         , hb_enabled_(false)
@@ -166,6 +167,14 @@ public:
 
     void set_next_log_idx(ulong idx) {
         next_log_idx_ = idx;
+    }
+
+    ulong get_next_log_idx_floor() const {
+        return next_log_idx_floor_;
+    }
+
+    void set_next_log_idx_floor(ulong idx) {
+        next_log_idx_floor_ = idx;
     }
 
     uint64_t get_last_accepted_log_idx() const {
@@ -456,6 +465,13 @@ private:
      * The last log index whose term matches up with the leader.
      */
     ulong matched_idx_;
+
+    /**
+     * Floor for `next_log_idx_`, set after successful snapshot sync.
+     * Prevents stale RPC responses from rewinding `next_log_idx_`
+     * below the snapshot-established position.
+     */
+    ulong next_log_idx_floor_;
 
     /**
      * `true` if we sent message to this server and waiting for

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -262,6 +262,7 @@ bool raft_server::request_append_entries(ptr<peer> p) {
                  p->get_id(), p_next_log_idx, p->get_matched_idx());
             p->set_next_log_idx(0);
             p->set_matched_idx(0);
+            p->set_next_log_idx_floor(0);
         }
         p->clear_reconnection();
     }
@@ -1262,7 +1263,14 @@ void raft_server::handle_append_entries_resp(resp_msg& resp) {
         ulong prev_next_log = p->get_next_log_idx();
         if (resp.get_next_idx() > 0 && prev_next_log > resp.get_next_idx()) {
             // fast move for the peer to catch up
-            p->set_next_log_idx(resp.get_next_idx());
+            ulong floor = p->get_next_log_idx_floor();
+            ulong target = std::max(resp.get_next_idx(), floor);
+            if (target != resp.get_next_idx()) {
+                p_wn("fast-move clamped to snapshot floor: "
+                     "resp next_idx %" PRIu64 ", floor %" PRIu64,
+                     resp.get_next_idx(), floor);
+            }
+            p->set_next_log_idx(target);
         } else {
             bool do_log_rewind = true;
             // If not, check an extra order exists.
@@ -1284,7 +1292,15 @@ void raft_server::handle_append_entries_resp(resp_msg& resp) {
             // if not, move one log backward.
             // WARNING: Make sure that `next_log_idx_` shouldn't be smaller than 0.
             if (do_log_rewind && prev_next_log) {
-                p->set_next_log_idx(prev_next_log - 1);
+                ulong floor = p->get_next_log_idx_floor();
+                if (prev_next_log - 1 >= floor) {
+                    p->set_next_log_idx(prev_next_log - 1);
+                } else {
+                    p_wn("skip log rewind: next_log_idx %" PRIu64
+                         " would go below snapshot floor %" PRIu64
+                         ", resp next_idx %" PRIu64,
+                         prev_next_log - 1, floor, resp.get_next_idx());
+                }
             }
         }
         bool suppress = p->need_to_suppress_error();

--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -365,6 +365,8 @@ void raft_server::handle_install_snapshot_resp(resp_msg& resp) {
                 p_db("snapshot sync is done (raw type)");
                 p->set_next_log_idx(sync_ctx->get_snapshot()->get_last_log_idx() + 1);
                 p->set_matched_idx(sync_ctx->get_snapshot()->get_last_log_idx());
+                p->set_next_log_idx_floor(
+                    sync_ctx->get_snapshot()->get_last_log_idx() + 1);
                 clear_snapshot_sync_ctx(*p);
 
                 if (p->is_snapshot_sync_needed()) {
@@ -389,6 +391,7 @@ void raft_server::handle_install_snapshot_resp(resp_msg& resp) {
               "log_store_->next_slot(): %" PRIu64,
               p->get_id(), p->get_next_log_idx(), log_store_->next_slot() );
         p->set_next_log_idx(resp.get_next_idx());
+        p->set_next_log_idx_floor(0);
 
         // Added by Jung-Sang Ahn (Oct 11 2017)
         // Declining snapshot implies that the peer already has the up-to-date snapshot.

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1114,6 +1114,7 @@ void raft_server::become_leader() {
             // reconnect_client(*pp);
 
             pp->set_next_log_idx(log_store_->next_slot());
+            pp->set_next_log_idx_floor(0);
             pp->reset_stream();
             enable_hb_for_peer(*pp);
             pp->set_recovered();

--- a/tests/unit/fake_network.cxx
+++ b/tests/unit/fake_network.cxx
@@ -269,6 +269,15 @@ void FakeNetwork::handleAllFrom(const std::string& endpoint) {
     while (handleRespFrom(endpoint));
 }
 
+bool FakeNetwork::replaceLastPendingResp(const std::string& endpoint,
+                                         ptr<resp_msg> new_resp) {
+    ptr<FakeClient> conn = findClient(endpoint);
+    if (!conn || conn->pendingResps.empty()) return false;
+    auto& last = conn->pendingResps.back();
+    last.resp = new_resp;
+    return true;
+}
+
 size_t FakeNetwork::getNumPendingReqs(const std::string& endpoint) {
     ptr<FakeClient> conn = findClient(endpoint);
     if (!conn) return 0;

--- a/tests/unit/fake_network.hxx
+++ b/tests/unit/fake_network.hxx
@@ -145,6 +145,51 @@ public:
         return false;
     }
 
+    ulong getPeerNextLogIdxFloor(raft_server* srv, int32 peer_id) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            return it->second->get_next_log_idx_floor();
+        }
+        return 0;
+    }
+
+    void setPeerNextLogIdx(raft_server* srv, int32 peer_id, ulong idx) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            it->second->set_next_log_idx(idx);
+        }
+    }
+
+    void setPeerMatchedIdx(raft_server* srv, int32 peer_id, ulong idx) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            it->second->set_matched_idx(idx);
+        }
+    }
+
+    void setPeerNextLogIdxFloor(raft_server* srv, int32 peer_id, ulong idx) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            it->second->set_next_log_idx_floor(idx);
+        }
+    }
+
+    ulong getPeerNextLogIdx(raft_server* srv, int32 peer_id) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            return it->second->get_next_log_idx();
+        }
+        return 0;
+    }
+
+    bool replaceLastPendingResp(const std::string& endpoint,
+                                ptr<resp_msg> new_resp);
+
     void setPeerSnapshotInSync(raft_server* srv,
                                int32 peer_id,
                                ptr<snapshot> snp) {

--- a/tests/unit/snapshot_test.cxx
+++ b/tests/unit/snapshot_test.cxx
@@ -1129,6 +1129,176 @@ int snapshot_null_snapshot_join_test() {
     return 0;
 }
 
+// Regression test for stale-RPC-after-snapshot backward probing bug.
+//
+// Production scenario: after snapshot sync completes, a force-reconnect
+// resets next_log_idx to 0. The stale install_snapshot_response arrives
+// and correctly sets next_log_idx = S+1. Then a stale append_entries
+// denial arrives with NextIndex = S+1 (== next_log_idx). The strict `>`
+// in the fast-move check fails, and the decrement path walks backward
+// through the entire log (~15 minutes in production).
+//
+// This test verifies that next_log_idx_floor_, set during snapshot
+// completion, prevents the backward spiral.
+int snapshot_rewind_floor_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( launch_servers( pkgs ) );
+    CHK_Z( make_group( pkgs ) );
+
+    ExecArgs exec_args(&s1);
+    TestSuite::ThreadHolder hh(&exec_args, fake_executer, fake_executer_killer);
+
+    for (auto& entry: pkgs) {
+        RaftPkg* pp = entry;
+        raft_params param = pp->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        param.snapshot_distance_ = 5;
+        pp->raftServer->update_params(param);
+    }
+
+    // Append 5 entries, replicate to S2 only (S3 lags behind).
+    for (size_t ii = 0; ii < 5; ++ii) {
+        std::string test_msg = "test" + std::to_string(ii);
+        ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+        msg->put(test_msg);
+        exec_args.setMsg(msg);
+        exec_args.eaExecuter.invoke();
+        TestSuite::sleep_ms(EXECUTOR_WAIT_MS);
+        CHK_NULL( exec_args.getMsg().get() );
+
+        s1.fNet->execReqResp("S2");
+        s1.fNet->execReqResp("S2");
+        CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    }
+
+    // S3 is lagging behind. Make requests to S3 fail to force snapshot path.
+    s1.fNet->makeReqFail("S3");
+
+    // Trigger heartbeat to S3 — initiates snapshot transmission.
+    s1.fTimer->invoke(timer_task_type::heartbeat_timer);
+    s1.fNet->execReqResp();
+
+    // Send the entire snapshot.
+    do {
+        s1.fNet->execReqResp();
+    } while (s3.raftServer->is_receiving_snapshot());
+
+    s1.fNet->execReqResp();
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+
+    // All servers should be in sync.
+    CHK_OK( s2.getTestSm()->isSame( *s1.getTestSm() ) );
+    CHK_OK( s3.getTestSm()->isSame( *s1.getTestSm() ) );
+
+    // --- Verify floor was set after snapshot sync ---
+    ulong floor = s1.fNet->getPeerNextLogIdxFloor(s1.raftServer.get(), 3);
+    ulong next_idx = s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3);
+    CHK_GT( floor, 0 );
+    CHK_SMEQ( floor, next_idx );
+
+    // Record the snapshot boundary.
+    ulong snapshot_floor = floor;
+    ulong current_term = s1.raftServer->get_term();
+
+    // --- Phase 1: Test decrement-path clamping (exact production scenario) ---
+    // Set up the post-race state: next_log_idx == floor == snapshot boundary.
+    // A denial with NextIndex == next_log_idx makes the strict `>` check fail,
+    // falling to the decrement path. The floor must prevent the decrement.
+    s1.fNet->setPeerNextLogIdx(s1.raftServer.get(), 3, snapshot_floor);
+    s1.fNet->setPeerMatchedIdx(s1.raftServer.get(), 3, 0);
+    s1.fNet->setPeerNextLogIdxFloor(s1.raftServer.get(), 3, snapshot_floor);
+
+    // Trigger heartbeat → creates append_entries request to S3.
+    s1.fTimer->invoke(timer_task_type::heartbeat_timer);
+    // Deliver request to S3, getting a real response into the pending queue.
+    s1.fNet->delieverReqTo("S3");
+    // Replace the real (accepted) response with a crafted denial.
+    // NextIndex = snapshot_floor: same as next_log_idx, so `>` fails.
+    {
+        ptr<resp_msg> denial = cs_new<resp_msg>(
+            current_term,
+            msg_type::append_entries_response,
+            3,   // src = S3
+            1,   // dst = S1
+            snapshot_floor,  // next_idx == next_log_idx
+            false);          // accepted = false
+        s1.fNet->replaceLastPendingResp("S3", denial);
+    }
+    // Deliver the crafted denial to S1's response handler.
+    s1.fNet->handleRespFrom("S3");
+
+    // Verify: next_log_idx must NOT have decremented below the floor.
+    ulong after_phase1 =
+        s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3);
+    CHK_GTEQ( after_phase1, snapshot_floor );
+
+    // --- Phase 2: Test fast-move clamping ---
+    // Set next_log_idx above the floor. A denial with NextIndex below the
+    // floor triggers the fast-move path, but the floor must clamp it.
+    s1.fNet->setPeerNextLogIdx(
+        s1.raftServer.get(), 3, snapshot_floor + 5);
+
+    s1.fTimer->invoke(timer_task_type::heartbeat_timer);
+    s1.fNet->delieverReqTo("S3");
+    {
+        // NextIndex = 1: far below the floor, fast-move would jump there.
+        ptr<resp_msg> denial = cs_new<resp_msg>(
+            current_term,
+            msg_type::append_entries_response,
+            3,   // src = S3
+            1,   // dst = S1
+            1,   // next_idx far below floor
+            false);
+        s1.fNet->replaceLastPendingResp("S3", denial);
+    }
+    s1.fNet->handleRespFrom("S3");
+
+    // Verify: fast-move was clamped to the floor, not to 1.
+    ulong after_phase2 =
+        s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3);
+    CHK_GTEQ( after_phase2, snapshot_floor );
+
+    // --- Phase 3: Verify recovery after floor is exercised ---
+    // Restore proper state and confirm normal replication still works.
+    s1.fNet->setPeerNextLogIdx(s1.raftServer.get(), 3, snapshot_floor);
+    s1.fNet->setPeerMatchedIdx(
+        s1.raftServer.get(), 3, snapshot_floor - 1);
+    for (int ii = 0; ii < 5; ++ii) {
+        s1.fTimer->invoke(timer_task_type::heartbeat_timer);
+        s1.fNet->execReqResp();
+        s1.fNet->execReqResp();
+    }
+
+    ulong final_next_idx =
+        s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3);
+    CHK_GTEQ( final_next_idx, snapshot_floor );
+
+    print_stats(pkgs);
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+
+    fake_executer_killer(&exec_args);
+    hh.join();
+    CHK_Z( hh.getResult() );
+
+    f_base->destroy();
+
+    return 0;
+}
+
 } // namespace snapshot_test
 using namespace snapshot_test;
 
@@ -1169,6 +1339,9 @@ int main(int argc, char* argv[]) {
 
     ts.doTest( "snapshot null snapshot join test",
                snapshot_null_snapshot_join_test );
+
+    ts.doTest( "snapshot rewind floor test",
+               snapshot_rewind_floor_test );
 
 #ifdef ENABLE_RAFT_STATS
     _msg("raft stats: ENABLED\n");


### PR DESCRIPTION
After snapshot sync, a race between a stale RPC response and a force-reconnect can leave `next_log_idx` equal to the follower's `NextIndex` hint. The strict `>` in the fast-move check fails when they're equal, so the decrement path kicks in and walks backward one entry at a time (~15 minutes in production before log compaction forces a new snapshot).

The fix adds a `next_log_idx_floor_` field to the peer class, set to `snapshot_last_log_idx + 1` on snapshot completion. Both the fast-move and decrement paths are clamped to never go below this floor. The floor is cleared on force-reconnect, snapshot decline, and leader election, so when it's 0 all paths behave identically to the unpatched code.

The regression test injects crafted denial responses to exercise both protected paths, and was verified by removing the floor logic and confirming the test fails.