### PR TITLE
Refactor STREAM_FORWARDING (#98) into `client_req_stream` API 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,7 @@ set(RAFT_CORE
     ${ASIO_SERVICE_SRC}
     ${ROOT_SRC}/buffer.cxx
     ${ROOT_SRC}/buffer_serializer.cxx
+    ${ROOT_SRC}/client_req_stream.cxx
     ${ROOT_SRC}/cluster_config.cxx
     ${ROOT_SRC}/crc32.cxx
     ${ROOT_SRC}/error_code.cxx

--- a/docs/stream_forwarding.md
+++ b/docs/stream_forwarding.md
@@ -1,0 +1,115 @@
+Pipelined Client Request Forwarding
+====================================
+
+`client_req_stream` is a single-channel, ordered, fail-closed forwarding
+path from any raft node to the current leader. It exists to send many
+dependent client writes without waiting for commit between them, at the
+cost of tearing the stream down on any ambiguity.
+
+Obtain via `raft_server::open_client_req_stream`; see
+`include/libnuraft/client_req_stream.hxx` for the API.
+
+Semantics
+---------
+
+* **Ordering.** Across `append` calls on one stream, order is preserved
+  end-to-end. If a batch commits, every previously-sent batch on the same
+  stream committed too with a lower `log_idx`. Guarantee: some prefix of
+  the sent sequence is applied, no gaps.
+
+* **Fail-closed.** Any stream-fatal outcome (leader rejection, transport
+  error, local leader-term divergence) breaks the stream permanently; the
+  caller discards it and opens a new one. The failing `append` surfaces
+  the leader's `result_code`; only subsequent sends observe the transport
+  break.
+
+* **Term fencing.** The stream snapshots leader id + term at open. Each
+  forwarded request carries that term so the leader rejects on mismatch.
+  `is_broken()` also returns true as soon as the local `raft_server`'s
+  term diverges from the fenced term.
+
+* **Cheap local path.** When the leader is this node, the stream is a
+  thin wrapper over `append_entries_ext` with `expected_term_` set.
+
+Preconditions
+-------------
+
+* **`async_replication` + transport pipelining** must both be on. The
+  cluster config must have `async_replication` enabled (otherwise the
+  leader serializes responses behind `client_req_timeout_` and
+  pipelining buys nothing), and the local `asio_service` must have
+  `streaming_mode_` enabled (otherwise overlapping sends hit a
+  busy-socket assert). `open_client_req_stream` returns nullptr if
+  either is missing.
+
+* **All cluster peers must understand `STREAM_FORWARDING`** (remote path
+  only). Not runtime-checked — mixed-version rollout is a consciously
+  accepted unsupported mode for this feature. A per-feature ACK bit was
+  considered and declined: it would reinvent capability negotiation
+  per-feature, which is the wrong abstraction for NuRaft. The correct
+  long-term answer is a general peer-capability handshake, which is
+  outside the scope of this change. Until that exists, this feature
+  follows the same deployment discipline as `async_replication` did:
+  precondition + operator runbook, not runtime enforcement. See the
+  Operator Runbook below for the rollout procedure.
+
+* **In-flight queue is unbounded.** `rpc_client` does not limit queued
+  sends; a faster-than-leader producer will grow the queue without
+  back-pressure. Bound it in the caller.
+
+* **Don't combine with `cb_func` hooks that use `ReturnNull` to cancel
+  client writes.** If `PreAppendLogLeader`, `AppendLogs`, or
+  `AppendLogFailed` returns `ReturnNull` mid-batch on a stream-forwarded
+  request, the leader closes the rpc session without a response after a
+  prefix has already been stored. On retry the client may re-submit the
+  same batch and duplicate the committed prefix — the no-gap guarantee
+  does not hold against this path. If you need these hooks, dedup at
+  the state-machine layer or don't use stream forwarding. (Conservative:
+  some technically-safe cases exist — e.g. `PreAppendLogLeader`
+  returning `ReturnNull` at `i == 0` before any entry is stored — but
+  treat "any hook + `ReturnNull` + stream forwarding" as unsupported
+  unless you've read `src/handle_client_request.cxx`.)
+
+Operator Runbook — rolling upgrades
+-----------------------------------
+
+Because the peer-version precondition is not runtime-checked, a rollout
+that introduces the `STREAM_FORWARDING` wire flag needs a two-phase
+ordering: upgrade every node in the cluster first, *then* allow any
+caller to open streams. If a stream opens against a pre-flag peer, the
+old leader silently drops the flag and term fencing doesn't apply; a
+subsequent stream break can leave a committed prefix that a retry then
+duplicates.
+
+The failure mode is **duplicated commits in the log, not data loss**.
+If the state machine dedups client operations (session + request
+counter or similar), the window is harmless. Otherwise you'll see a
+request apply twice in or just after the upgrade window; reconcile from
+the raft log, or accept the duplicates and wait out the upgrade.
+
+Wire flag (internal)
+--------------------
+
+`req_msg::STREAM_FORWARDING_REQUEST` is serialized as `STREAM_FORWARDING`
+(0x80) in the asio header. On the leader:
+
+1. `req_msg::term` is treated as `expected_term_` (see the WARNING in
+   `req_msg.hxx`); without the flag it is ignored.
+2. On rejection, `rpc_session` writes the response back then tears the
+   session down, so the failing `append` sees the real `result_code`
+   and subsequent sends see transport break.
+
+No-gap invariant
+----------------
+
+The close-on-reject check looks only at `resp->get_accepted()` (not the
+cb/async_cb chain). Safe because `handle_cli_req` routes every
+`accepted=false` return through `reject_cli_req` above the store loop —
+so after the first `store_log_entry` the response is always accepted,
+and any later failure (CANCELLED/TIMEOUT) can only come from a term
+change, which rolls back all uncommitted entries of the old term
+together.
+
+`cb_func` hooks that return `ReturnNull` mid-batch are a separate
+hazard — not protected by this structural invariant. See the
+precondition in the Preconditions section above.

--- a/include/libnuraft/client_req_stream.hxx
+++ b/include/libnuraft/client_req_stream.hxx
@@ -1,0 +1,102 @@
+/************************************************************************
+Copyright 2024-present ClickHouse, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**************************************************************************/
+
+#ifndef _CLIENT_REQ_STREAM_HXX_
+#define _CLIENT_REQ_STREAM_HXX_
+
+#include "async.hxx"
+#include "buffer.hxx"
+#include "ptr.hxx"
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace nuraft {
+
+class raft_server;
+class rpc_client;
+
+/**
+ * Single-channel, ordered, fail-closed stream of client_request batches to
+ * the current leader. See `docs/stream_forwarding.md` for semantics,
+ * preconditions, and the no-gap invariant.
+ *
+ * Obtain via `raft_server::open_client_req_stream`.
+ */
+class client_req_stream {
+public:
+    // Prefer `raft_server::open_client_req_stream`. `rpc == nullptr`
+    // selects the local fast path (delegates to `append_entries_ext`).
+    client_req_stream(wptr<raft_server> srv,
+                      int32_t local_id,
+                      uint64_t fenced_term,
+                      ptr<rpc_client> rpc = nullptr,
+                      uint64_t send_timeout_ms = 0);
+
+    ~client_req_stream();
+
+    /**
+     * True once the stream is broken — either latched by `append` after
+     * a stream-fatal outcome, or observed live when the local
+     * `raft_server`'s term has diverged from the fenced term. Pure
+     * observation, safe from any thread, cheap (two atomic loads).
+     */
+    bool is_broken() const;
+
+    /**
+     * Append a batch. **Not thread-safe**: callers must serialize
+     * `append` calls on the same stream. Ordering across serialized
+     * calls is preserved.
+     *
+     * Result contract: `accepted=true, OK` on success; otherwise
+     * `accepted=false` with a non-OK `result_code`. Callers should
+     * distinguish `CANCELLED` (client-side short-circuit when already
+     * broken, no I/O) from anything else (leader's verbatim code on
+     * remote rejection, or `FAILED` on transport exception).
+     *
+     * On the local path, if `append_entries_ext` throws the stream is
+     * latched broken before the exception propagates.
+     */
+    ptr< cmd_result< ptr<buffer> > >
+        append(std::vector< ptr<buffer> > logs);
+
+private:
+    ptr< cmd_result< ptr<buffer> > >
+        append_local(std::vector< ptr<buffer> > logs);
+    ptr< cmd_result< ptr<buffer> > >
+        append_remote(std::vector< ptr<buffer> > logs);
+
+    // Shared with in-flight completion callbacks so they can still flip
+    // `broken_` after the stream is destroyed. `srv_` is weak so a stream
+    // outliving the server becomes permanently broken rather than
+    // dangling.
+    struct shared_state {
+        std::atomic<bool> broken_{false};
+        uint64_t fenced_term_;
+        int32_t local_id_;          // stamped as `src` on forwarded reqs
+        wptr<raft_server> srv_;
+    };
+
+    ptr<rpc_client> rpc_;   // null for local path
+    uint64_t send_timeout_ms_;
+    ptr<shared_state> state_;
+};
+
+} // namespace nuraft
+
+#endif // _CLIENT_REQ_STREAM_HXX_

--- a/include/libnuraft/nuraft.hxx
+++ b/include/libnuraft/nuraft.hxx
@@ -26,6 +26,7 @@ limitations under the License.
 #include "buffer.hxx"
 #include "buffer_serializer.hxx"
 #include "callback.hxx"
+#include "client_req_stream.hxx"
 #include "cluster_config.hxx"
 #include "context.hxx"
 #include "delayed_task_scheduler.hxx"

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -44,6 +44,7 @@ namespace nuraft {
 
 using CbReturnCode = cb_func::ReturnCode;
 
+class client_req_stream;
 class cluster_config;
 class custom_notification_msg;
 class delayed_task_scheduler;
@@ -359,6 +360,20 @@ public:
     ptr< cmd_result< ptr<buffer> > >
         append_entries_ext(const std::vector< ptr<buffer> >& logs,
                            const req_ext_params& ext_params);
+
+    /**
+     * Open a pipelined-forwarding stream bound to the current leader and
+     * term. See `client_req_stream.hxx` and `docs/stream_forwarding.md`.
+     *
+     * On failure returns nullptr and (if non-null) sets `*out_err`:
+     *   CANCELLED  — async_replication disabled on the cluster config
+     *   NOT_LEADER — no current leader or term==0
+     *   FAILED     — leader not in cluster config, rpc_client creation
+     *                failed, or transport does not support pipelining
+     */
+    ptr<client_req_stream> open_client_req_stream(
+        uint64_t send_timeout_ms = 0,
+        cmd_result_code* out_err = nullptr);
 
     enum class PrioritySetResult { SET, BROADCAST, IGNORED };
 

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -1126,7 +1126,7 @@ protected:
     virtual void commit_in_bg();
     bool commit_in_bg_exec(size_t timeout_ms = 0, bool initial_commit_exec = false);
 
-    void append_entries_in_bg();
+    virtual void append_entries_in_bg();
     void append_entries_in_bg_exec();
 
     void commit_app_log(ulong idx_to_commit,

--- a/include/libnuraft/req_msg.hxx
+++ b/include/libnuraft/req_msg.hxx
@@ -34,8 +34,7 @@ public:
     // This flag is used only when full consensus mode is enabled.
     static constexpr uint64_t EXCLUDED_FROM_THE_QUORUM = 0x1;
 
-    // If set, the STREAM_FORWARDING wire flag is included in the
-    // request header, and client reconnect is disabled.
+    // If set, the STREAM_FORWARDING wire flag is included in the request header.
     // See the comment on STREAM_FORWARDING in asio_service.cxx for details.
     static constexpr uint64_t STREAM_FORWARDING_REQUEST = 0x2;
 

--- a/include/libnuraft/req_msg.hxx
+++ b/include/libnuraft/req_msg.hxx
@@ -34,8 +34,13 @@ public:
     // This flag is used only when full consensus mode is enabled.
     static constexpr uint64_t EXCLUDED_FROM_THE_QUORUM = 0x1;
 
-    // If set, the STREAM_FORWARDING wire flag is included in the request header.
-    // See the comment on STREAM_FORWARDING in asio_service.cxx for details.
+    // On an outgoing client_request: emits the STREAM_FORWARDING wire
+    // flag and repurposes `term_` as the stream's fenced term (see
+    // docs/stream_forwarding.md).
+    //
+    // WARNING: this flag overloads `term_` on client_request. Readers of
+    // `term_` on a client_request must check this flag first. New flags
+    // should use a dedicated field rather than another `term_` overload.
     static constexpr uint64_t STREAM_FORWARDING_REQUEST = 0x2;
 
     req_msg(ulong term,

--- a/include/libnuraft/req_msg.hxx
+++ b/include/libnuraft/req_msg.hxx
@@ -34,6 +34,11 @@ public:
     // This flag is used only when full consensus mode is enabled.
     static constexpr uint64_t EXCLUDED_FROM_THE_QUORUM = 0x1;
 
+    // If set, the STREAM_FORWARDING wire flag is included in the
+    // request header, and client reconnect is disabled.
+    // See the comment on STREAM_FORWARDING in asio_service.cxx for details.
+    static constexpr uint64_t STREAM_FORWARDING_REQUEST = 0x2;
+
     req_msg(ulong term,
             msg_type type,
             int32 src,

--- a/include/libnuraft/rpc_cli.hxx
+++ b/include/libnuraft/rpc_cli.hxx
@@ -47,6 +47,14 @@ public:
     virtual uint64_t get_id() const = 0;
 
     virtual bool is_abandoned() const = 0;
+
+    /**
+     * True if the client accepts a second `send` before the previous
+     * send's `when_done` has fired (pipelining). If false, overlapping
+     * sends violate the client's contract (e.g. the asio client asserts
+     * on a busy socket unless streaming_mode_ is enabled).
+     */
+    virtual bool supports_pipelining() const { return false; }
 };
 
 }

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -1177,7 +1177,6 @@ public:
         , socket_(io_svc)
         , ssl_socket_(socket_, ssl_ctx)
         , attempting_conn_(false)
-        , conn_attempts_(0)
         , host_(host)
         , port_(port)
         , ssl_enabled_(ssl_enabled)
@@ -1364,19 +1363,7 @@ public:
                 // Already opened, skip async_connect.
                 p_wn("race: socket to %s:%s is already opened, escape",
                      host_.c_str(), port_.c_str());
-                bool exp2 = true;
-                attempting_conn_.compare_exchange_strong(exp2, false);
                 break;
-            }
-
-            size_t prev_conn_attempts = conn_attempts_.fetch_add(1);
-            if ( prev_conn_attempts > 0 &&
-                 (req->get_extra_flags() & req_msg::STREAM_FORWARDING_REQUEST)) {
-                abandoned_ = true;
-                std::string err_msg =
-                    "connection lost, not reconnecting because of STREAM_FORWARDING_REQUEST flag";
-                handle_error(req, err_msg, when_done);
-                return;
             }
 
             if (impl_->get_options().custom_resolver_) {
@@ -2109,10 +2096,10 @@ private:
     asio::ip::tcp::resolver resolver_;
     asio::ip::tcp::socket socket_;
     ssl_socket ssl_socket_;
-    // `true` if attempting connection is in progress.
-    // Other threads should not do anything.
+    // `false` if we never tried connecting yet.
+    // We don't have connection retries, so this changes from false
+    // to true at most once and stays true.
     std::atomic<bool> attempting_conn_;
-    std::atomic<size_t> conn_attempts_;
     std::string host_;
     std::string port_;
     bool ssl_enabled_;

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -147,43 +147,10 @@ limitations under the License.
 //     the follower is marked down by itself.
 #define MARK_DOWN (0x40)
 
-// Can be used for sending multiple dependent writes to the leader in a streaming fashion,
-// i.e. with guaranteed ordering but without waiting for commit after each request.
-// Somewhat difficult to use correctly. Tailored to a particular usage in clickhouse.
-//
-// We'd like to pass appends through chain: rpc_client -> (TCP) -> rpc_session -> raft_server,
-// with no reordering or gaps at any step. Same guarantees as TCP: if an append succeeds
-// (i.e. eventually ends up committed, whether or not acked to the original writer),
-// all previous appends must've succeeded too, in the original order.
-// I.e. some prefix of the request sequence is applied, no gaps. On any error,
-// the stream becomes permanently "closed", and the client has to establish a new stream.
-//
-// Recipe for such streaming:
-//  * The client side is any raft node, the server side is the leader raft node.
-//  * On client side, get current leader's term using raft_server::get_term()
-//    and remember it for the duration of the stream.
-//  * NuRaft's own auto_forwarding feature should not be used as it doesn't provide
-//    sufficient control over connection management. Instead, use rpc_client_factory
-//    directly to connect to the leader node. Form msg_type::client_request messages manually
-//    and send them through one rpc_client in the correct order.
-//  * In the client_request messages, set the STREAM_FORWARDING_REQUEST flag and
-//    set `term` field to the stream's term.
-//    This flag tells rpc_client to avoid reconnecting if TCP connection is closed,
-//    and tells rpc_session to close TCP connection if any append is rejected.
-//  * If the rpc_client reports an error, consider the stream closed.
-//    Periodically re-check raft_server::get_term(); if it changes, consider the stream closed.
-//  * To get any performance gain from streaming, you probably want to enable
-//    async_replication in cluster_config and streaming_mode_ in asio_service_options.
-//    With async_replication, responses to client_request messages don't mean much,
-//    so you probably want to ignore them (but still check for errors, to detect when TCP
-//    connection is closed) and use commit callback as confirmation of durability.
-//  * If the connection is closed, you probably want to report error for all in-flight
-//    uncommitted requests and close their corresponding upstream user sessions.
-//    For that, you probably want to maintain the set (or queue) of in-flight requests:
-//    add entry to the set before sending to the leader, remove in commit callback.
-//  * You should probably use backoff when reconnecting. E.g. during recovery the leader
-//    will be rejecting all requests, so every STREAM_FORWARDING connection will be closed
-//    quickly on first request.
+// Wire flag for `client_req_stream` forwarding (see client_req_stream.hxx
+// and docs/stream_forwarding.md). When set, rpc_session treats req_msg.term
+// as expected_term_ for fencing, and tears down the session on rejection
+// instead of writing a response.
 #define STREAM_FORWARDING (0x80)
 
 // =======================
@@ -781,7 +748,8 @@ private:
         }
 
         raft_server::req_ext_params ext_params;
-        if (req->get_term() != 0) {
+        // Only STREAM_FORWARDING client_requests use term for fencing.
+        if ((flags_ & STREAM_FORWARDING) && req->get_term() != 0) {
             ext_params.expected_term_ = req->get_term();
         }
 
@@ -789,22 +757,6 @@ private:
         ptr<resp_msg> resp = raft_server_handler::process_req(handler_.get(), *req, ext_params);
         if (!resp) {
             p_wn("no response is returned from raft message handler");
-            this->stop();
-            return;
-        }
-
-        if ((flags_ & STREAM_FORWARDING) && !resp->get_accepted()) {
-            // Close stream on error to avoid reordering.
-            //
-            // We only check get_accepted() here without doing call_cb()/call_async_cb() first.
-            // This is sufficient because non-immediate errors (i.e. failing
-            // to replicate/commit the entry) can only happen on term change and
-            // do not cause reordering or gaps.
-            // Also, STREAM_FORWARDING is normally used with async replication enabled,
-            // so there shouldn't be any cb or async_cb.
-            //
-            // Currently we don't send the response in this case because the current user of
-            // STREAM_FORWARDING (clickhouse) doesn't care about responses.
             this->stop();
             return;
         }
@@ -847,6 +799,11 @@ private:
 
     void on_resp_ready(ptr<req_msg> req, ptr<resp_msg> resp) {
         ptr<rpc_session> self = this->shared_from_this();
+
+        enum class post_write_action {
+            cont,   // wait for the next request on this session
+            stop,   // tear the session down after the write flushes
+        };
 
        try {
         ptr<buffer> resp_ctx = resp->get_ctx();
@@ -932,21 +889,31 @@ private:
             bs.put_i32(resp->get_result_code());
         }
 
+        // Teardown decision for STREAM_FORWARDING. Computed here, after
+        // write_resp_meta_ may have mutated resp, so it reflects the
+        // final resp the write will emit.
+        const post_write_action post =
+            ((flags_ & STREAM_FORWARDING) && !resp->get_accepted())
+                ? post_write_action::stop
+                : post_write_action::cont;
+
         aa::write( ssl_enabled_, ssl_socket_, socket_,
                    asio::buffer(resp_buf->data_begin(), resp_buf->size()),
-                   [this, self, resp_buf]
+                   [this, self, resp_buf, post]
                    (ERROR_CODE err_code, size_t) -> void
         {
             // To avoid releasing `resp_buf` before the write is done.
             (void)resp_buf;
-            if (!err_code) {
-                this->start(self);
-            } else {
+            if (err_code) {
                 p_er( "session %" PRIu64 " failed to send response to peer due "
                       "to error %d",
                       session_id_,
                       err_code.value() );
                 this->stop();
+            } else if (post == post_write_action::stop) {
+                this->stop();
+            } else {
+                this->start(self);
             }
         } );
 
@@ -1220,6 +1187,10 @@ public:
 
     bool is_abandoned() const override {
         return abandoned_;
+    }
+
+    bool supports_pipelining() const override {
+        return impl_->get_options().streaming_mode_;
     }
 
 #ifndef SSL_LIBRARY_NOT_FOUND

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -147,6 +147,45 @@ limitations under the License.
 //     the follower is marked down by itself.
 #define MARK_DOWN (0x40)
 
+// Can be used for sending multiple dependent writes to the leader in a streaming fashion,
+// i.e. with guaranteed ordering but without waiting for commit after each request.
+// Somewhat difficult to use correctly. Tailored to a particular usage in clickhouse.
+//
+// We'd like to pass appends through chain: rpc_client -> (TCP) -> rpc_session -> raft_server,
+// with no reordering or gaps at any step. Same guarantees as TCP: if an append succeeds
+// (i.e. eventually ends up committed, whether or not acked to the original writer),
+// all previous appends must've succeeded too, in the original order.
+// I.e. some prefix of the request sequence is applied, no gaps. On any error,
+// the stream becomes permanently "closed", and the client has to establish a new stream.
+//
+// Recipe for such streaming:
+//  * The client side is any raft node, the server side is the leader raft node.
+//  * On client side, get current leader's term using raft_server::get_term()
+//    and remember it for the duration of the stream.
+//  * NuRaft's own auto_forwarding feature should not be used as it doesn't provide
+//    sufficient control over connection management. Instead, use rpc_client_factory
+//    directly to connect to the leader node. Form msg_type::client_request messages manually
+//    and send them through one rpc_client in the correct order.
+//  * In the client_request messages, set the STREAM_FORWARDING_REQUEST flag and
+//    set `term` field to the stream's term.
+//    This flag tells rpc_client to avoid reconnecting if TCP connection is closed,
+//    and tells rpc_session to close TCP connection if any append is rejected.
+//  * If the rpc_client reports an error, consider the stream closed.
+//    Periodically re-check raft_server::get_term(); if it changes, consider the stream closed.
+//  * To get any performance gain from streaming, you probably want to enable
+//    async_replication in cluster_config and streaming_mode_ in asio_service_options.
+//    With async_replication, responses to client_request messages don't mean much,
+//    so you probably want to ignore them (but still check for errors, to detect when TCP
+//    connection is closed) and use commit callback as confirmation of durability.
+//  * If the connection is closed, you probably want to report error for all in-flight
+//    uncommitted requests and close their corresponding upstream user sessions.
+//    For that, you probably want to maintain the set (or queue) of in-flight requests:
+//    add entry to the set before sending to the leader, remove in commit callback.
+//  * You should probably use backoff when reconnecting. E.g. during recovery the leader
+//    will be rejecting all requests, so every STREAM_FORWARDING connection will be closed
+//    quickly on first request.
+#define STREAM_FORWARDING (0x80)
+
 // =======================
 
 namespace nuraft {
@@ -741,10 +780,31 @@ private:
             }
         }
 
+        raft_server::req_ext_params ext_params;
+        if (req->get_term() != 0) {
+            ext_params.expected_term_ = req->get_term();
+        }
+
         // === RAFT server processes the request here. ===
-        ptr<resp_msg> resp = raft_server_handler::process_req(handler_.get(), *req);
+        ptr<resp_msg> resp = raft_server_handler::process_req(handler_.get(), *req, ext_params);
         if (!resp) {
             p_wn("no response is returned from raft message handler");
+            this->stop();
+            return;
+        }
+
+        if ((flags_ & STREAM_FORWARDING) && !resp->get_accepted()) {
+            // Close stream on error to avoid reordering.
+            //
+            // We only check get_accepted() here without doing call_cb()/call_async_cb() first.
+            // This is sufficient because non-immediate errors (i.e. failing
+            // to replicate/commit the entry) can only happen on term change and
+            // do not cause reordering or gaps.
+            // Also, STREAM_FORWARDING is normally used with async replication enabled,
+            // so there shouldn't be any cb or async_cb.
+            //
+            // Currently we don't send the response in this case because the current user of
+            // STREAM_FORWARDING (clickhouse) doesn't care about responses.
             this->stop();
             return;
         }
@@ -1117,6 +1177,7 @@ public:
         , socket_(io_svc)
         , ssl_socket_(socket_, ssl_ctx)
         , attempting_conn_(false)
+        , conn_attempts_(0)
         , host_(host)
         , port_(port)
         , ssl_enabled_(ssl_enabled)
@@ -1303,7 +1364,19 @@ public:
                 // Already opened, skip async_connect.
                 p_wn("race: socket to %s:%s is already opened, escape",
                      host_.c_str(), port_.c_str());
+                bool exp2 = true;
+                attempting_conn_.compare_exchange_strong(exp2, false);
                 break;
+            }
+
+            size_t prev_conn_attempts = conn_attempts_.fetch_add(1);
+            if ( prev_conn_attempts > 0 &&
+                 (req->get_extra_flags() & req_msg::STREAM_FORWARDING_REQUEST)) {
+                abandoned_ = true;
+                std::string err_msg =
+                    "connection lost, not reconnecting because of STREAM_FORWARDING_REQUEST flag";
+                handle_error(req, err_msg, when_done);
+                return;
             }
 
             if (impl_->get_options().custom_resolver_) {
@@ -1385,6 +1458,10 @@ public:
         if (req->get_extra_flags() & req_msg::EXCLUDED_FROM_THE_QUORUM) {
             // If the request is excluded from the quorum, set the flag.
             flags |= MARK_DOWN;
+        }
+
+        if (req->get_extra_flags() & req_msg::STREAM_FORWARDING_REQUEST) {
+            flags |= STREAM_FORWARDING;
         }
 
         for (auto& entry: req->log_entries()) {
@@ -2035,6 +2112,7 @@ private:
     // `true` if attempting connection is in progress.
     // Other threads should not do anything.
     std::atomic<bool> attempting_conn_;
+    std::atomic<size_t> conn_attempts_;
     std::string host_;
     std::string port_;
     bool ssl_enabled_;

--- a/src/client_req_stream.cxx
+++ b/src/client_req_stream.cxx
@@ -1,0 +1,250 @@
+/************************************************************************
+Copyright 2024-present ClickHouse, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**************************************************************************/
+
+#include "client_req_stream.hxx"
+
+#include "cluster_config.hxx"
+#include "context.hxx"
+#include "log_val_type.hxx"
+#include "msg_type.hxx"
+#include "raft_server.hxx"
+#include "req_msg.hxx"
+#include "resp_msg.hxx"
+#include "rpc_cli.hxx"
+#include "rpc_cli_factory.hxx"
+#include "rpc_exception.hxx"
+#include "srv_config.hxx"
+#include "tracer.hxx"
+
+namespace nuraft {
+
+namespace {
+
+ptr< cmd_result< ptr<buffer> > > make_ready(cmd_result_code code, bool accepted) {
+    auto res = cs_new< cmd_result< ptr<buffer> > >();
+    if (accepted) {
+        res->accept();
+    }
+    ptr<buffer> nil_buf;
+    ptr<std::exception> nil_err;
+    res->set_result(nil_buf, nil_err, code);
+    return res;
+}
+
+} // anonymous namespace
+
+client_req_stream::client_req_stream(wptr<raft_server> srv,
+                                     int32_t local_id,
+                                     uint64_t fenced_term,
+                                     ptr<rpc_client> rpc,
+                                     uint64_t send_timeout_ms)
+    : rpc_(rpc)
+    , send_timeout_ms_(send_timeout_ms)
+    , state_(cs_new<shared_state>())
+{
+    state_->srv_ = std::move(srv);
+    state_->local_id_ = local_id;
+    state_->fenced_term_ = fenced_term;
+}
+
+client_req_stream::~client_req_stream() = default;
+
+bool client_req_stream::is_broken() const {
+    if (state_->broken_.load(std::memory_order_acquire)) return true;
+    auto srv = state_->srv_.lock();
+    if (!srv) return true;
+    return srv->get_term() != state_->fenced_term_;
+}
+
+ptr< cmd_result< ptr<buffer> > >
+client_req_stream::append(std::vector< ptr<buffer> > logs)
+{
+    if (is_broken()) {
+        state_->broken_.store(true, std::memory_order_release);
+        return make_ready(cmd_result_code::CANCELLED, /*accepted=*/false);
+    }
+    // Empty batches are a no-op; avoid append_entries_ext's accepted=false
+    // early-return that would wrongly mark the stream broken.
+    if (logs.empty()) {
+        return make_ready(cmd_result_code::OK, /*accepted=*/true);
+    }
+    return rpc_ ? append_remote(std::move(logs))
+                : append_local(std::move(logs));
+}
+
+ptr< cmd_result< ptr<buffer> > >
+client_req_stream::append_local(std::vector< ptr<buffer> > logs)
+{
+    auto srv = state_->srv_.lock();
+    if (!srv) {
+        state_->broken_.store(true, std::memory_order_release);
+        return make_ready(cmd_result_code::CANCELLED, /*accepted=*/false);
+    }
+
+    raft_server::req_ext_params ext;
+    ext.expected_term_ = state_->fenced_term_;
+
+    ptr< cmd_result< ptr<buffer> > > res;
+    try {
+        res = srv->append_entries_ext(logs, ext);
+    } catch (...) {
+        // Latch broken before rethrowing — a mid-batch throw from
+        // store_log_entry may leave a partial prefix in the log.
+        state_->broken_.store(true, std::memory_order_release);
+        throw;
+    }
+
+    auto state = state_;
+    res->when_ready(
+        [state]
+        (cmd_result< ptr<buffer> >& r, ptr<std::exception>&) {
+            if (!r.get_accepted() ||
+                r.get_result_code() != cmd_result_code::OK) {
+                state->broken_.store(true, std::memory_order_release);
+            }
+        });
+    return res;
+}
+
+ptr< cmd_result< ptr<buffer> > >
+client_req_stream::append_remote(std::vector< ptr<buffer> > logs)
+{
+    // term = fenced term (see WARNING on STREAM_FORWARDING_REQUEST in req_msg.hxx).
+    ptr<req_msg> req = cs_new<req_msg>(
+        state_->fenced_term_, msg_type::client_request,
+        /*src*/ state_->local_id_, /*dst*/ 0,
+        /*last_log_term*/ 0, /*last_log_idx*/ 0, /*commit_idx*/ 0);
+    req->set_extra_flags(req_msg::STREAM_FORWARDING_REQUEST);
+    req->log_entries().reserve(logs.size());
+    for (auto& buf : logs) {
+        buf->pos(0);
+        req->log_entries().push_back(
+            cs_new<log_entry>(0, buf, log_val_type::app_log));
+    }
+
+    auto res = cs_new< cmd_result< ptr<buffer> > >();
+    auto state = state_;
+    // One-shot latch so a partially-queued send can't let both the handler
+    // and the catch block complete `res`.
+    auto completed = cs_new<std::atomic<bool>>(false);
+    auto try_complete =
+        [res](std::atomic<bool>& once, ptr<buffer> buf,
+              ptr<std::exception> err, cmd_result_code code) {
+            bool expected = false;
+            if (once.compare_exchange_strong(expected, true)) {
+                res->set_result(buf, err, code);
+            }
+        };
+
+    rpc_handler handler =
+        [res, state, completed, try_complete]
+        (ptr<resp_msg>& resp, ptr<rpc_exception>& err) {
+            ptr<buffer> ret_buf;
+            ptr<std::exception> ret_err =
+                err ? std::static_pointer_cast<std::exception>(err) : nullptr;
+            cmd_result_code code = cmd_result_code::OK;
+
+            if (err || !resp) {
+                state->broken_.store(true, std::memory_order_release);
+                code = cmd_result_code::FAILED;
+            } else if (!resp->get_accepted()) {
+                state->broken_.store(true, std::memory_order_release);
+                code = resp->get_result_code();
+                // Invariant: accepted=false always carries non-OK
+                // (reject_cli_req). OK here means protocol violation.
+                if (code == cmd_result_code::OK) code = cmd_result_code::FAILED;
+            } else {
+                res->accept();
+                ret_buf = resp->get_ctx();
+            }
+
+            try_complete(*completed, ret_buf, ret_err, code);
+        };
+    try {
+        rpc_->send(req, handler, send_timeout_ms_);
+    } catch (...) {
+        // No-op if the handler already ran (latched by `completed`).
+        state_->broken_.store(true, std::memory_order_release);
+        try_complete(*completed, ptr<buffer>{}, ptr<std::exception>{},
+                     cmd_result_code::FAILED);
+    }
+    return res;
+}
+
+// ---- factory -------------------------------------------------------------
+
+ptr<client_req_stream> raft_server::open_client_req_stream(
+    uint64_t send_timeout_ms,
+    cmd_result_code* out_err)
+{
+    auto fail = [&](cmd_result_code code) -> ptr<client_req_stream> {
+        if (out_err) *out_err = code;
+        return nullptr;
+    };
+
+    ptr<cluster_config> cfg = get_config();
+    if (!cfg || !cfg->is_async_replication()) {
+        p_wn("open_client_req_stream: refused - async_replication is disabled");
+        return fail(cmd_result_code::CANCELLED);
+    }
+
+    // leader/term reads aren't atomic together; a stale snapshot self-heals
+    // on the first append via the term fence.
+    int32 leader = get_leader();
+    if (leader == -1) {
+        p_wn("open_client_req_stream: refused - no current leader");
+        return fail(cmd_result_code::NOT_LEADER);
+    }
+
+    ulong term = get_term();
+    if (term == 0) {
+        p_wn("open_client_req_stream: refused - raft state not initialized");
+        return fail(cmd_result_code::NOT_LEADER);
+    }
+
+    wptr<raft_server> srv_weak = this->shared_from_this();
+
+    if (leader == id_) {
+        return cs_new<client_req_stream>(srv_weak, id_, term);
+    }
+
+    ptr<srv_config> srv_cfg = cfg->get_server(leader);
+    if (!srv_cfg) {
+        p_wn("open_client_req_stream: refused - leader %d not in cluster config",
+             leader);
+        return fail(cmd_result_code::FAILED);
+    }
+
+    ptr<rpc_client> rpc =
+        ctx_->rpc_cli_factory_->create_client(srv_cfg->get_endpoint());
+    if (!rpc) {
+        p_wn("open_client_req_stream: refused - rpc_client creation failed "
+             "for endpoint %s", srv_cfg->get_endpoint().c_str());
+        return fail(cmd_result_code::FAILED);
+    }
+    // Without pipelining, a second in-flight append hits a busy-socket assert.
+    if (!rpc->supports_pipelining()) {
+        p_wn("open_client_req_stream: refused - rpc_client for endpoint %s "
+             "does not support pipelining (streaming_mode_ not enabled?)",
+             srv_cfg->get_endpoint().c_str());
+        return fail(cmd_result_code::FAILED);
+    }
+
+    return cs_new<client_req_stream>(
+        srv_weak, id_, term, rpc, send_timeout_ms);
+}
+
+} // namespace nuraft

--- a/src/handle_client_request.cxx
+++ b/src/handle_client_request.cxx
@@ -73,6 +73,23 @@ ptr<resp_msg> raft_server::handle_leader_status_req(req_msg& req) {
     }
 }
 
+namespace {
+
+// Sole source of `accepted=false` responses in handle_cli_req. All rejections
+// must stay in the pre-store phase so STREAM_FORWARDING close-on-reject
+// preserves no-gap semantics (see docs/stream_forwarding.md).
+ptr<resp_msg> reject_cli_req(uint64_t cur_term,
+                             int32 id,
+                             int32 leader,
+                             cmd_result_code code) {
+    ptr<resp_msg> resp = cs_new<resp_msg>(
+        cur_term, msg_type::append_entries_response, id, leader);
+    resp->set_result_code(code);
+    return resp;
+}
+
+} // anonymous namespace
+
 ptr<resp_msg> raft_server::handle_cli_req_prelock(req_msg& req,
                                                   const req_ext_params& ext_params)
 {
@@ -124,29 +141,34 @@ ptr<resp_msg> raft_server::handle_cli_req(req_msg& req,
                                           const req_ext_params& ext_params,
                                           uint64_t timestamp_us)
 {
-    ptr<resp_msg> resp = nullptr;
+    // Three phases: (1) pre-store validation, (2) append/store,
+    // (3) completion setup. All accepted=false returns must stay in (1)
+    // (routed through reject_cli_req) — STREAM_FORWARDING depends on this.
+
+    // --- Phase 1: pre-store validation ---
+
     ulong last_idx = 0;
     ptr<buffer> ret_value = nullptr;
     ulong resp_idx = 1;
     ulong cur_term = state_->get_term();
     ptr<raft_params> params = ctx_->get_params();
 
-    resp = cs_new<resp_msg>( cur_term,
-                             msg_type::append_entries_response,
-                             id_,
-                             leader_ );
     if (role_ != srv_role::leader || write_paused_) {
-        resp->set_result_code( cmd_result_code::NOT_LEADER );
-        return resp;
+        return reject_cli_req(cur_term, id_, leader_, cmd_result_code::NOT_LEADER);
     }
 
     if (ext_params.expected_term_) {
         // If expected term is given, check the current term.
         if (ext_params.expected_term_ != cur_term) {
-            resp->set_result_code( cmd_result_code::TERM_MISMATCH );
-            return resp;
+            return reject_cli_req(cur_term, id_, leader_,
+                                  cmd_result_code::TERM_MISMATCH);
         }
     }
+
+    ptr<resp_msg> resp = cs_new<resp_msg>(
+        cur_term, msg_type::append_entries_response, id_, leader_);
+
+    // --- Phase 2: append/store ---
 
     std::vector< ptr<log_entry> >& entries = req.log_entries();
 
@@ -221,6 +243,8 @@ ptr<resp_msg> raft_server::handle_cli_req(req_msg& req,
         timer_helper::sleep_us(sleep_us);
     }
 
+    // --- Phase 3: completion setup (resp is always accepted from here) ---
+
     if (!get_config()->is_async_replication()) {
         // Sync replication:
         //   Set callback function for `last_idx`.
@@ -270,6 +294,12 @@ ptr<resp_msg> raft_server::handle_cli_req(req_msg& req,
     }
 
     resp->accept(resp_idx);
+    // Structural invariant: accepted=false only comes from reject_cli_req
+    // above the store loop (see STREAM_FORWARDING no-gap).
+    if (!resp->get_accepted()) {
+        p_ft("handle_cli_req: phase-3 response not accepted; no-gap violated");
+        assert(false);
+    }
     return resp;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,13 @@ unit_test(NAME learner_new_joiner_test
     ${EXAMPLES_SRC}/logger.cc
     ${EXAMPLES_SRC}/in_memory_log_store.cxx)
 
+unit_test(NAME client_req_stream_test
+    SOURCES
+    unit/client_req_stream_test.cxx
+    unit/fake_network.cxx
+    ${EXAMPLES_SRC}/logger.cc
+    ${EXAMPLES_SRC}/in_memory_log_store.cxx)
+
 # === Failure recovery & conflict resolution test ===
 unit_test(NAME failure_test
     SOURCES

--- a/tests/unit/client_req_stream_test.cxx
+++ b/tests/unit/client_req_stream_test.cxx
@@ -1,0 +1,164 @@
+/************************************************************************
+Copyright 2024-present ClickHouse, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**************************************************************************/
+
+// Local-path unit tests for client_req_stream. The remote (STREAM_FORWARDING
+// wire) path is covered by the ClickHouse Keeper integration tests.
+
+#include "fake_network.hxx"
+#include "raft_package_fake.hxx"
+#include "fake_executer.hxx"
+
+#include "client_req_stream.hxx"
+#include "cluster_config.hxx"
+#include "test_common.h"
+
+using namespace nuraft;
+using namespace raft_functional_common;
+
+namespace client_req_stream_test {
+
+namespace {
+
+// Start a 3-node group with a leader on S1, optionally flipping every node's
+// runtime cluster_config to async_replication afterward.
+int launch_group_with_async_replication(std::vector<RaftPkg*>& pkgs,
+                                        bool async_replication) {
+    CHK_Z(launch_servers(pkgs));
+    CHK_Z(make_group(pkgs));
+    if (async_replication) {
+        for (auto& pkg : pkgs) {
+            pkg->raftServer->get_config()->set_async_replication(true);
+        }
+    }
+    return 0;
+}
+
+} // anonymous namespace
+
+int open_rejects_sync_replication() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    RaftPkg s1(f_base, 1, "S1");
+    RaftPkg s2(f_base, 2, "S2");
+    RaftPkg s3(f_base, 3, "S3");
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z(launch_group_with_async_replication(pkgs, /*async_replication=*/false));
+
+    // Sync replication (default) → factory must refuse with CANCELLED.
+    cmd_result_code err = cmd_result_code::OK;
+    ptr<client_req_stream> stream =
+        s1.raftServer->open_client_req_stream(/*send_timeout_ms=*/0, &err);
+    CHK_NULL(stream.get());
+    CHK_EQ(cmd_result_code::CANCELLED, err);
+
+    // Flip the runtime config to async and confirm a stream can now be opened.
+    ptr<cluster_config> rt = s1.raftServer->get_config();
+    rt->set_async_replication(true);
+    // get_config() returns a shared config object, so no additional plumbing is
+    // needed for the leader to observe the change.
+    stream = s1.raftServer->open_client_req_stream();
+    CHK_NONNULL(stream.get());
+    CHK_FALSE(stream->is_broken());
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+    f_base->destroy();
+    return 0;
+}
+
+int local_stream_append_happy_path() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    RaftPkg s1(f_base, 1, "S1");
+    RaftPkg s2(f_base, 2, "S2");
+    RaftPkg s3(f_base, 3, "S3");
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z(launch_group_with_async_replication(pkgs, /*async_replication=*/true));
+
+    ptr<client_req_stream> stream = s1.raftServer->open_client_req_stream();
+    CHK_NONNULL(stream.get());
+    CHK_FALSE(stream->is_broken());
+
+    std::string test_msg = "payload";
+    ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+    msg->put(test_msg);
+
+    std::vector<ptr<buffer>> logs{msg};
+    ptr<cmd_result<ptr<buffer>>> res = stream->append(std::move(logs));
+    CHK_NONNULL(res.get());
+    CHK_TRUE(res->get_accepted());
+    CHK_FALSE(stream->is_broken());
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+    f_base->destroy();
+    return 0;
+}
+
+int append_empty_batch_is_no_op() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    RaftPkg s1(f_base, 1, "S1");
+    RaftPkg s2(f_base, 2, "S2");
+    RaftPkg s3(f_base, 3, "S3");
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z(launch_group_with_async_replication(pkgs, /*async_replication=*/true));
+
+    ptr<client_req_stream> stream = s1.raftServer->open_client_req_stream();
+    CHK_NONNULL(stream.get());
+
+    // Empty batches short-circuit to accepted=true, OK without touching
+    // append_entries_ext (which would report accepted=false, OK for empty).
+    std::vector<ptr<buffer>> empty;
+    ptr<cmd_result<ptr<buffer>>> res = stream->append(std::move(empty));
+    CHK_NONNULL(res.get());
+    CHK_TRUE(res->has_result());
+    CHK_TRUE(res->get_accepted());
+    CHK_EQ(cmd_result_code::OK, res->get_result_code());
+    CHK_FALSE(stream->is_broken());
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+    f_base->destroy();
+    return 0;
+}
+
+} // namespace client_req_stream_test
+
+using namespace client_req_stream_test;
+
+int main(int argc, char** argv) {
+    TestSuite ts(argc, argv);
+    ts.options.printTestMessage = true;
+
+    ts.doTest("open rejects sync replication",
+              open_rejects_sync_replication);
+    ts.doTest("local stream append happy path",
+              local_stream_append_happy_path);
+    ts.doTest("append empty batch is no-op",
+              append_empty_batch_is_no_op);
+
+    return 0;
+}


### PR DESCRIPTION
It's a PR to #98 :) 

## Summary

Replace the ad-hoc "recipe in a comment" contract that Keeper followed to forward pipelined client requests to the leader with a typed NuRaft abstraction: `raft_server::open_client_req_stream()` returns a `client_req_stream` that is single-channel, ordered, fail-closed, and term-fenced to the current leader. The local fast path delegates to `append_entries_ext`; the remote path owns one `rpc_client` and sends `client_request` messages with the `STREAM_FORWARDING` wire flag.

Along the way, fixes a real back-compat bug on the server side and tightens several latent failure modes that the old hand-rolled code had.

## Fixes and improvements vs. baseline

### correctness fixes 

1. **`expected_term_` gating on the wire flag.** Before this change,  any non-zero `client_request.term` was treated as a term fence on the  leader, even for callers that didn't opt into STREAM_FORWARDING. That  broke any external `raft_server_handler::process_req` user whose  `client_request` happened to carry a term. The check is now strictly  gated on the `STREAM_FORWARDING` wire flag.

2. **Empty-batch no-op.** Old Keeper code, if called with an empty  `requests_for_sessions`, forwarded an empty batch to  `append_entries_ext`, which returns `accepted=false, OK` — old code  then treated that as fatal and broke the stream. The stream now  short-circuits empty batches.

3. **Local-path exception safety.** If `append_entries_ext` throws   synchronously (e.g. `store_log_entry` mid-batch fail), the old code   let the exception propagate without latching the Keeper `is_broken`   flag, so subsequent `isBroken()` checks returned `false` on an   already-broken stream. The new path latches `broken` in a   `try/catch` before rethrowing.

4. **Remote-path send-throw + double-completion.** If `rpc_client::send`   threw synchronously after partially queuing the handler, both the   handler and the catch block could complete the `cmd_result`. A   one-shot CAS latch now guarantees exactly one completion wins.

5. **Meta-callback teardown race.** The STREAM_FORWARDING   teardown-on-reject decision is now computed inside `on_resp_ready`   *after* `write_resp_meta_` runs. Without this, a meta callback that   mutates `resp->accepted_` could desync the teardown from the   serialized response and leave the session open on a rejection.

### API hygiene / robustness

6. **Typed API.** `raft_server::open_client_req_stream` →   `client_req_stream`. Keeper no longer hand-builds `req_msg`, flips   `STREAM_FORWARDING_REQUEST`, or reaches into   `asio_service::create_client` /   `get_config()->get_server()->get_endpoint()`.

7. **`async_replication` precondition checked** at open time. Old code   silently serialized behind `client_req_timeout_` in sync mode,   collapsing throughput with no diagnostic.

8. **`streaming_mode_` precondition checked** via new   `rpc_client::supports_pipelining()` virtual (default `false`; `asio_rpc_client` overrides to return `streaming_mode_`). Without it,   a second in-flight `append` used to hit the busy-socket assertion   in `asio_rpc_client::register_req_send`.

9. **Lifetime safety.** Stream holds `wptr<raft_server>`; a destroyed   server makes the stream permanently broken rather than dereferencing   stale state. In-flight completion callbacks share a   `ptr<shared_state>` so they can still latch broken after the stream   is destroyed.

10. **Correct `src` on forwarded `req_msg`.** Old Keeper used `src=0`,    which is a legal server id and confused peer-id-sensitive    `cb_func` hooks. The stream now stamps the local server id.

11. **Diagnostic factory return.** `open_client_req_stream` takes an    optional `cmd_result_code* out_err` so callers can log the specific    reason the stream could not be opened (`CANCELLED` /    `NOT_LEADER` / `FAILED`). Keeper uses this for log lines.

### Invariant / maintainability

12. **Structural no-gap invariant in `handle_cli_req`.** New    `reject_cli_req` helper is the sole funnel for `accepted=false`    responses, all of them in the pre-store phase. A three-phase    banner (validate / append+store / completion) makes the structural    rule visible, and a phase-3 runtime guard (`p_ft` + `assert(false)`)    catches any future regression that would silently break    STREAM_FORWARDING's close-on-reject correctness.

13. **`supports_pipelining()` transport capability.** New virtual on    `rpc_client`; alternate transports can cleanly opt in.

14. **Docs moved to `docs/stream_forwarding.md`.** Semantics,    preconditions, wire-flag mechanics, no-gap invariant proof sketch,    and an Operator Runbook for rolling upgrades are in a    discoverable file instead of a 40-line comment in    `asio_service.cxx`.

15. **Umbrella include.** `nuraft.hxx` now exposes `client_req_stream`    so consumers get the full API via the standard entry point.

16. **Reduced Keeper ↔ NuRaft coupling.** Keeper went from ~8 direct    NuRaft internal symbols (`req_msg`, `msg_type`, `log_val_type`,    `STREAM_FORWARDING_REQUEST`, `asio_service::create_client`,    `get_config()`, `srv_config::get_endpoint()`, `rpc_client::send`)    down to one: `raft_instance->open_client_req_stream(timeout_ms, &err)`.

17. **Unit tests.** Three deterministic tests cover previously-uncovered    behaviors: `async_replication` refusal with reason-code check,    local happy path, and empty-batch no-op.

## Consciously not fixed (documented scope)

- **Rolling-upgrade silent degrade.** Against a peer that doesn't  understand `STREAM_FORWARDING` the flag is silently ignored and the  no-gap guarantee doesn't hold during the upgrade window. A per-feature  ACK bit was considered and explicitly declined (would reinvent  capability negotiation per-feature, wrong abstraction for NuRaft).

  Feature follows the same deployment discipline as `async_replication`  did: precondition + operator runbook, not runtime enforcement. The  correct long-term answer is a general peer-capability handshake,  outside the scope of this change.

- **`cb_func::ReturnNull` combined with stream forwarding.** Documented  as unsupported. `PreAppendLogLeader` / `AppendLogs` /  `AppendLogFailed` `ReturnNull` mid-batch always closed the session
  with a stored prefix — latent corruption on retry. Original NuRaft  ABI retained as-is for this PR; fixing it cleanly needs a version bump/CHANGELOG path that this fork does not expose.

- **Mid-batch `store_log_entry` throw.** The stored prefix will  replicate; the stream breaks. No layer can fix this — callers need  state-machine-level dedup if they want exactly-once on retry.

## Verification

- NuRaft unit tests: `client_req_stream_test` 3/3, `raft_server_test`  21/21.
- ClickHouse build clean. 
- `test_keeper_multinode_simple` integration suite: 5/5.

## Keeper consumer

That makes `src/Coordination/KeeperAppendStream.cpp` look like that:

```cpp
#include <Coordination/KeeperAppendStream.h>

#if USE_NURAFT

#include <Coordination/KeeperServer.h>
#include <Coordination/CoordinationSettings.h>

namespace DB
{

namespace CoordinationSetting
{
    extern const CoordinationSettingsMilliseconds operation_timeout_ms;
}

KeeperAppendStream::KeeperAppendStream(KeeperServer * server_)
    : server(server_)
    , log(getLogger("KeeperAppendStream"))
{}

namespace
{
    const char * codeToString(nuraft::cmd_result_code code)
    {
        switch (code)
        {
            case nuraft::cmd_result_code::OK: return "OK";
            case nuraft::cmd_result_code::CANCELLED: return "CANCELLED (async_replication disabled)";
            case nuraft::cmd_result_code::NOT_LEADER: return "NOT_LEADER (no current leader or raft state uninitialized)";
            case nuraft::cmd_result_code::FAILED: return "FAILED (leader not in config, rpc_client creation failed, or transport does not support pipelining)";
            default: return "unexpected code";
        }
    }
}

bool KeeperAppendStream::isBroken() const
{
    return is_broken->load() || (stream && stream->is_broken());
}

void KeeperAppendStream::markAsBroken()
{
    is_broken->store(true);
}

void KeeperAppendStream::putRequestBatch(const KeeperRequestsForSessions & requests_for_sessions, std::function<void(bool)> callback)
{
    auto fail = [&]
    {
        is_broken->store(true);
        if (callback)
            callback(false);
    };

    if (isBroken())
    {
        fail();
        return;
    }

    if (!stream)
    {
        const uint64_t send_timeout_ms = server->keeper_context->getCoordinationSettings()[CoordinationSetting::operation_timeout_ms].totalMilliseconds();
        nuraft::cmd_result_code err = nuraft::cmd_result_code::OK;
        stream = server->raft_instance->open_client_req_stream(send_timeout_ms, &err);
        if (!stream)
        {
            LOG_WARNING(log, "Failed to open client_req_stream: {}", codeToString(err));
            fail();
            return;
        }
    }

    std::vector<nuraft::ptr<nuraft::buffer>> entries;
    entries.reserve(requests_for_sessions.size());
    for (const auto & request_for_session : requests_for_sessions)
        entries.push_back(IKeeperStateMachine::getZooKeeperLogEntry(request_for_session));

    auto res = stream->append(std::move(entries));
    res->when_ready(
        [is_broken_ = is_broken, callback](nuraft::cmd_result<nuraft::ptr<nuraft::buffer>> & r, nuraft::ptr<std::exception> &)
        {
            const bool accepted = r.get_accepted() && r.get_result_code() == nuraft::cmd_result_code::OK;
            if (!accepted)
                is_broken_->store(true);
            if (callback)
                callback(accepted);
        });
}

}

#endif
```
