### PR TITLE
Move cmd_result::code_ write inside the lock guard in set_result

### DIFF
--- a/include/libnuraft/async.hxx
+++ b/include/libnuraft/async.hxx
@@ -172,8 +172,8 @@ public:
      */
     void set_result(T& result, TE& err, cmd_result_code code = cmd_result_code::OK) {
         bool call_handler = false;
-        code_ = code;
         {   std::lock_guard<std::mutex> guard(lock_);
+            code_ = code;
             result_ = result;
             err_ = err;
             has_result_ = true;


### PR DESCRIPTION
ThreadSanitizer (running ClickHouse Keeper builds with `-DSANITIZE=thread`) reports a data race on `code_` between two concurrent `cmd_result::set_result` calls on the same `cmd_result` instance. The race surfaces as a chronic flaky integration test in ClickHouse CI (`test_read_only_table/test.py::test_restart_zookeeper` on `Integration tests (amd_tsan, …)`).

Stack:

```
WARNING: ThreadSanitizer: data race (pid=1)
  Write of size 4 at 0x... by thread T18:
    #0 nuraft::cmd_result<...>::set_result(...) include/libnuraft/async.hxx:175:15
    #1 nuraft::peer::handle_rpc_result(...) src/peer.cxx:171:25
  Previous write of size 4 at 0x... by thread T20:
    #0 nuraft::cmd_result<...>::set_result(...) include/libnuraft/async.hxx:175:15
SUMMARY: ThreadSanitizer: data race include/libnuraft/async.hxx:175:15 in nuraft::cmd_result<...>::set_result
```

### Root cause

`cmd_result::code_` is currently written by `set_result` *outside* the lock that protects every other `code_` access on the type. The current shape is:

```cpp
void set_result(T& result, TE& err, cmd_result_code code = cmd_result_code::OK) {
    bool call_handler = false;
    code_ = code;                              // <-- outside lock_
    {   std::lock_guard<std::mutex> guard(lock_);
        result_ = result;
        err_ = err;
        has_result_ = true;
        if (handler_ || handler2_) call_handler = true;
    }
    ...
}
```

Compare with the symmetric writers and the reader, which *do* hold `lock_`:

```cpp
void reset() {
    std::lock_guard<std::mutex> guard(lock_);
    err_ = TE();
    code_ = cmd_result_code::OK;        // under lock_
    ...
}

void set_result_code(cmd_result_code ec) {
    std::lock_guard<std::mutex> guard(lock_);
    code_ = ec;                         // under lock_
}

cmd_result_code get_result_code() const {
    std::lock_guard<std::mutex> guard(lock_);
    if (has_result_) {
        return code_;                   // under lock_
    } else {
        return RESULT_NOT_EXIST_YET;
    }
}
```

So the existing locking contract is: every read/write of `code_` is serialized under `lock_`. `set_result` is the one violator. The TSan report is the direct consequence of that — two `set_result` calls writing `code_` concurrently, both outside `lock_`, race.

### Fix

Move the single `code_ = code;` line inside the existing `std::lock_guard<std::mutex>` region:

```cpp
void set_result(T& result, TE& err, cmd_result_code code = cmd_result_code::OK) {
    bool call_handler = false;
    {   std::lock_guard<std::mutex> guard(lock_);
        code_ = code;                          // now under lock_
        result_ = result;
        err_ = err;
        has_result_ = true;
        if (handler_ || handler2_) call_handler = true;
    }
    ...
}
```

This:

- makes `code_` follow the same locking discipline as `result_`/`err_`/`has_result_`,
- eliminates the TSan data-race finding,
- adds no new lock acquisitions (the lock is already taken on the very next line),
- preserves the existing `call_handler`/`cv_.notify_all()` behavior, which intentionally happens outside the critical section.

### Out of scope

This change addresses only the *data race on `code_`*. There is a separate higher-level question that the same TSan report hints at: whether `peer::handle_rpc_result` should ever legitimately race two `set_result` calls on the same `pending_result` (e.g. when a timeout and an actual RPC response are both delivered concurrently for an in-flight request). Either ordering also overwrites `result_`/`err_`/`has_result_`, so that scenario is itself questionable. I'm leaving that for a follow-up — fixing the locking discipline here is correct on its own and is what the TSan finding is actually about.

### How this was found

Chronic flaky CI integration test in ClickHouse:
- Test: `tests/integration/test_read_only_table/test.py::test_restart_zookeeper`
- Job: `Integration tests (amd_tsan, …)`
- CIDB: 18 hits in last 30 days across 11 distinct PRs, including master.
- The failure surfaces as `Exception: Sanitizer assert found for instance zoo3-1` during `cluster.shutdown()`, attributing the sanitizer report to a `clickhouse-keeper` container (the ClickHouse integration-test framework substitutes `clickhouse-keeper` for the ZooKeeper service slots when `use_keeper=True`, which is the default).

Once this lands here, I'll bump the `contrib/NuRaft` submodule in `ClickHouse/ClickHouse` and reference this PR in the description.

cc @CheSema @alesapin

Session: cron:clickhouse-ci-task-worker:20260512-154500