### PR TITLE
Make follower-side pipelining opt-in via request flag

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -1731,6 +1731,7 @@ protected:
         ulong last_entry_term;
         ptr<cmd_result<ptr<buffer>>> promise;
     };
+    std::mutex pending_follower_resps_lock_; // may be locked while holding lock_
     std::deque<pending_follower_resp> pending_follower_resps_;
 
     /**

--- a/include/libnuraft/req_msg.hxx
+++ b/include/libnuraft/req_msg.hxx
@@ -36,6 +36,13 @@ public:
     // This flag is used only when full consensus mode is enabled.
     static constexpr uint64_t EXCLUDED_FROM_THE_QUORUM = 0x1;
 
+    // If set, the receiver may start processing the next request from the
+    // same connection before sending the response to this one (responses
+    // are still in order). Set by leaders that use streaming mode
+    // (`raft_params::max_log_gap_in_stream_ > 0`); honored by followers
+    // with `raft_params::parallel_log_appending_` enabled.
+    static constexpr uint64_t ALLOW_ASYNC_LOG_APPENDING = 0x2;
+
     req_msg(ulong term,
             msg_type type,
             int32 src,

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -148,6 +148,9 @@ limitations under the License.
 //     the follower is marked down by itself.
 #define MARK_DOWN (0x40)
 
+// See `req_msg::ALLOW_ASYNC_LOG_APPENDING`.
+#define ALLOW_ASYNC_LOG_APPENDING_WIRE (0x80)
+
 // =======================
 
 namespace nuraft {
@@ -698,6 +701,10 @@ private:
         if (flags_ & MARK_DOWN) {
             req->set_extra_flags(
                 req->get_extra_flags() | req_msg::EXCLUDED_FROM_THE_QUORUM);
+        }
+        if (flags_ & ALLOW_ASYNC_LOG_APPENDING_WIRE) {
+            req->set_extra_flags(
+                req->get_extra_flags() | req_msg::ALLOW_ASYNC_LOG_APPENDING);
         }
 
         if (log_data_size > 0 && log_ctx) {
@@ -1449,6 +1456,10 @@ public:
         if (req->get_extra_flags() & req_msg::EXCLUDED_FROM_THE_QUORUM) {
             // If the request is excluded from the quorum, set the flag.
             flags |= MARK_DOWN;
+        }
+
+        if (req->get_extra_flags() & req_msg::ALLOW_ASYNC_LOG_APPENDING) {
+            flags |= ALLOW_ASYNC_LOG_APPENDING_WIRE;
         }
 
         for (auto& entry: req->log_entries()) {

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -675,22 +675,14 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,
         }
     }
 
-    return req;
-}
+    if (params->max_log_gap_in_stream_ > 0) {
+        // Streaming mode: let the follower pipeline the next request
+        // while this one's response is still pending.
+        req->set_extra_flags(
+            req->get_extra_flags() | req_msg::ALLOW_ASYNC_LOG_APPENDING);
+    }
 
-// Whether handle_append_entries should return a future that later
-// gets notified by notify_log_append_completion when log entries become durable.
-// This allows the leader to send multiple append_entries messages without waiting
-// for responses.
-// Only makes sense when parallel_log_appending_ and max_log_gap_in_stream_ are both enabled;
-// otherwise either the log store or the asio handler would wait for durability anyway.
-static bool should_use_async_log_appending(const raft_params& params) {
-    // Note: the max_log_gap_in_stream_ check is just a heuristic;
-    // we're interested in the max_log_gap_in_stream_ *on the leader node*,
-    // not on this node. But typically parameters are the same on all nodes
-    // in practice, so this is ok.
-    // This function's return value doesn't affect correctness either way.
-    return params.parallel_log_appending_ && params.max_log_gap_in_stream_ > 0;
+    return req;
 }
 
 ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
@@ -885,7 +877,11 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
     last_rcvd_append_entries_req_.reset();
 
     ptr<raft_params> params = ctx_->get_params();
-    bool async_log_appending = should_use_async_log_appending(*params);
+    // Pipelined processing requires both sides to opt in. Old NuRaft on
+    // either side falls back to the blocking path.
+    bool async_log_appending =
+        params->parallel_log_appending_ &&
+        (req.get_extra_flags() & req_msg::ALLOW_ASYNC_LOG_APPENDING);
 
     if (req.log_entries().size() > 0) {
         // Write logs to store, start from overlapped logs
@@ -1659,9 +1655,9 @@ void raft_server::notify_log_append_completion(bool ok) {
         }
     } else {
         ptr<raft_params> params = ctx_->get_params();
-        if (should_use_async_log_appending(*params)) {
-            // Follower: send responses for async append_entries
-            // requests whose entries became durable.
+        if (params->parallel_log_appending_) {
+            // Send responses for pipelined append_entries requests whose
+            // entries are now durable.
             std::vector<std::pair<ptr<cmd_result<ptr<buffer>>>, cmd_result_code>> resps;
             {
                 recur_lock(lock_);
@@ -1697,11 +1693,11 @@ void raft_server::notify_log_append_completion(bool ok) {
             for (auto& p: resps) {
                 p.first->set_result(empty_buf, no_err, p.second);
             }
-        } else {
-            assert(pending_follower_resps_.empty());
-            // Follower: wake up the waiting thread.
-            ea_follower_log_append_->invoke();
         }
+
+        // Wake the blocking-path waiter in `handle_append_entries`.
+        // No-op if nothing waits.
+        ea_follower_log_append_->invoke();
     }
 }
 

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -934,15 +934,18 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
 
             // Fail any pending async append_entries requests: any entries they refer to
             // are likely being rolled back, and leader term has changed.
-            if (!pending_follower_resps_.empty()) {
-                p_in( "rollback: discarding %zu pending pipelined responses",
-                      pending_follower_resps_.size() );
-                for (pending_follower_resp& resp: pending_follower_resps_) {
-                    ptr<buffer> empty_buf;
-                    ptr<std::exception> no_err;
-                    resp.promise->set_result(empty_buf, no_err, cmd_result_code::TERM_MISMATCH);
+            {
+                auto_lock(pending_follower_resps_lock_);
+                if (!pending_follower_resps_.empty()) {
+                    p_in( "rollback: discarding %zu pending pipelined responses",
+                        pending_follower_resps_.size() );
+                    for (pending_follower_resp& resp: pending_follower_resps_) {
+                        ptr<buffer> empty_buf;
+                        ptr<std::exception> no_err;
+                        resp.promise->set_result(empty_buf, no_err, cmd_result_code::TERM_MISMATCH);
+                    }
+                    pending_follower_resps_.clear();
                 }
-                pending_follower_resps_.clear();
             }
 
             // If rollback point is smaller than commit index,
@@ -1068,8 +1071,11 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
                           ", deferring response (pipelined)",
                           last_durable_index, required_durable );
                     auto promise = cs_new<cmd_result<ptr<buffer>>>();
-                    pending_follower_resps_.push_back(
-                        {required_durable, req.log_entries().back()->get_term(), promise});
+                    {
+                        auto_lock(pending_follower_resps_lock_);
+                        pending_follower_resps_.push_back(
+                            {required_durable, req.log_entries().back()->get_term(), promise});
+                    }
                     resp->set_async_cb([promise]() { return promise; });
 
                 } else {
@@ -1105,8 +1111,11 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
                     ", deferring response (pipelined)",
                     last_durable_index, required_durable );
             auto promise = cs_new<cmd_result<ptr<buffer>>>();
-            pending_follower_resps_.push_back(
-                {required_durable, /*last_entry_term=*/ 0, promise});
+            {
+                auto_lock(pending_follower_resps_lock_);
+                pending_follower_resps_.push_back(
+                    {required_durable, /*last_entry_term=*/ 0, promise});
+            }
             resp->set_async_cb([promise]() { return promise; });
         }
     }
@@ -1617,8 +1626,8 @@ ulong raft_server::get_expected_committed_log_idx() {
 
 void raft_server::notify_log_append_completion(bool ok) {
     if (stopping_) {
-        recur_lock(lock_);
         // Send errors for pending async append_entries requests.
+        auto_lock(pending_follower_resps_lock_);
         if (!pending_follower_resps_.empty()) {
             p_in( "discarding %zu pending pipelined responses",
                   pending_follower_resps_.size() );
@@ -1660,7 +1669,7 @@ void raft_server::notify_log_append_completion(bool ok) {
             // entries are now durable.
             std::vector<std::pair<ptr<cmd_result<ptr<buffer>>>, cmd_result_code>> resps;
             {
-                recur_lock(lock_);
+                auto_lock(pending_follower_resps_lock_);
                 if (!pending_follower_resps_.empty()) {
                     uint64_t durable_idx = log_store_->last_durable_index();
                     while ( !pending_follower_resps_.empty() &&
@@ -1675,12 +1684,12 @@ void raft_server::notify_log_append_completion(bool ok) {
                             // This should be impossible because we clear pending_follower_resps_
                             // when doing log_store_ rollback.
                             p_er( "term mismatch in async append_entries: "
-                                "appended entry with idx %" PRIu64 " "
-                                "term %" PRIu64 ", durable entry has "
-                                "term %" PRIu64,
-                                entry.last_entry_idx,
-                                entry.last_entry_term,
-                                term_in_log_store);
+                                  "appended entry with idx %" PRIu64 " "
+                                  "term %" PRIu64 ", durable entry has "
+                                  "term %" PRIu64,
+                                  entry.last_entry_idx,
+                                  entry.last_entry_term,
+                                  term_in_log_store);
                             resps.emplace_back(std::move(entry.promise), cmd_result_code::TERM_MISMATCH);
                         }
                         pending_follower_resps_.pop_front();


### PR DESCRIPTION
(You don't have to read the whole description, skimming is ok, just read the code.)

Prompt:
> contrib/NuRaft (submodule) commit 303dbdd broke compatibililty a little. Leader node ("client" side of rpc) needs commit df37a4f to be able to talk to follower node ("server" side of rpc) with async_log_appending=true (in handle_append_entries). Please fix it, so that no special procedure is needing when rolling-updating to the new version. Maybe something like this:
>  * Add a flag in the message where leader node can tell the follower node whether to use the new behavior. (E.g. flag `ALLOW_ASYNC_LOG_APPENDING` in `append_entries_request`. I.e. a flag in `req_msg` and a wire flag in `asio_service.cxx`.) Old client will never send this flag, so new server will use old behavior. Old server will ignore this flag when deserializing msg, and new client is ok with the flag being ignored (it only affects performance). (Check if all these statements are true.)
>  * Remove `should_use_async_log_appending` and instead: in `handle_append_entries` do `params.parallel_log_appending_ && <the new flag>`, in `notify_log_append_completion` do just `params.parallel_log_appending_`.
>  * This also resolves the awkward 'Note' in `should_use_async_log_appending`. Accordingly, make the sender set the `ALLOW_ASYNC_LOG_APPENDING` iff `params.max_log_gap_in_stream_ > 0`.
>
> First check if this plan is correct. IF everything makes sense, go ahead and implement it.
>
> (No need to add a test, this is already covered by clickhouse upgrade check in ci.)

---

Commit 303dbdd ("Actually async log appending on follower") let a follower start reading and processing the next `append_entries_request` on the same connection before sending the response to the previous one (responses still go out in order; durability requirements unchanged). The decision was driven purely by the follower's own `raft_params`, which broke compatibility with leaders that pre-date df37a4f ("asio_rpc_client overhaul") — that old client can't handle the resulting pipelined responses, so rolling upgrades required a specific node ordering.

Negotiate the behavior per-request instead. The leader sets the new `req_msg::ALLOW_ASYNC_LOG_APPENDING` flag iff it uses streaming mode (`max_log_gap_in_stream_ > 0`); the follower pipelines only when its own `parallel_log_appending_` is set *and* the request carries the flag.

Rolling upgrades are safe in both directions:
- Old leader → new follower: flag never set, follower uses the old blocking path.
- New leader → old follower: unknown wire flag bits are dropped, so the old follower keeps blocking; correctness preserved, just no pipelining benefit.

Also drops the awkward note in the removed `should_use_async_log_appending` about reading the follower's `max_log_gap_in_stream_` when what really mattered was the leader's.

`notify_log_append_completion` now gates the pipelined-resp drain on just `parallel_log_appending_` and always wakes `ea_follower_log_append_`, since blocking-mode and pipelined-mode requests can coexist in the new design.

No test added — covered by the ClickHouse upgrade check in CI.