### PR TITLE
Throttle backward append probes per peer

### DIFF
--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -70,6 +70,7 @@ public:
         , stale_rpc_responses_(0)
         , last_sent_idx_(0)
         , cnt_not_applied_(0)
+        , cnt_backward_log_probe_(0)
         , leave_requested_(false)
         , hb_cnt_since_leave_(0)
         , stepping_down_(false)
@@ -297,6 +298,10 @@ public:
     int32 inc_cnt_not_applied()         { cnt_not_applied_++;
                                           return cnt_not_applied_; }
     int32 get_cnt_not_applied() const   { return cnt_not_applied_; }
+
+    void reset_cnt_backward_log_probe()       { cnt_backward_log_probe_ = 0; }
+    int32 inc_cnt_backward_log_probe()        { return cnt_backward_log_probe_.fetch_add(1) + 1; }
+    int32 get_cnt_backward_log_probe() const  { return cnt_backward_log_probe_; }
 
     void step_down()                { stepping_down_ = true; }
     bool is_stepping_down() const   { return stepping_down_.load(); }
@@ -561,6 +566,12 @@ private:
      * Number of count where start log index is the same as previous.
      */
     std::atomic<int32> cnt_not_applied_;
+
+    /**
+     * Number of consecutive rejected append responses that moved
+     * `next_log_idx_` one step backward while probing for a matching log.
+     */
+    std::atomic<int32> cnt_backward_log_probe_;
 
     /**
      * `true` if leave request has been sent to this peer.

--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -78,6 +78,7 @@ struct raft_params {
         , enable_randomized_snapshot_creation_(false)
         , max_append_size_(100)
         , max_append_size_bytes_(0)
+        , append_entries_backward_probe_throttle_threshold_(5)
         , reserved_log_items_(100000)
         , client_req_timeout_(3000)
         , fresh_log_gap_(200)
@@ -168,6 +169,20 @@ struct raft_params {
      */
     raft_params& with_max_append_size_bytes(int64 size_bytes) {
         max_append_size_bytes_ = size_bytes;
+        return *this;
+    }
+
+    /**
+     * Number of consecutive backward log-match probes after which the leader
+     * limits appendEntries payloads to one log entry.
+     * If set to 0, the backward-probe payload throttle is disabled.
+     *
+     * @param threshold
+     * @return self
+     */
+    raft_params& with_append_entries_backward_probe_throttle_threshold(
+            int32 threshold) {
+        append_entries_backward_probe_throttle_threshold_ = threshold;
         return *this;
     }
 
@@ -459,6 +474,13 @@ public:
      * If set to 0, only max_append_size_ will be used.
      */
     int64 max_append_size_bytes_;
+
+    /**
+     * Number of consecutive backward log-match probes after which
+     * append entry requests are limited to one log entry.
+     * If set to 0, this throttle is disabled.
+     */
+    int32 append_entries_backward_probe_throttle_threshold_;
 
     /**
      * Minimum number of logs that will be preserved

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -100,6 +100,8 @@ struct resp_appendix {
     extra_order extra_order_;
 };
 
+const static int32 APPEND_ENTRIES_SAME_START_THROTTLE_THRESHOLD = 5;
+
 void raft_server::append_entries_in_bg() {
     std::string thread_name = "nuraft_append";
 #ifdef __linux__
@@ -457,6 +459,7 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,
         std::lock_guard<std::mutex> guard(p.get_lock());
         if (p.get_next_log_idx() == 0L) {
             p.set_next_log_idx(cur_nxt_idx);
+            p.reset_cnt_backward_log_probe();
         }
 
         if (custom_last_log_idx > 0) {
@@ -533,13 +536,26 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,
         int32 cur_cnt = p.inc_cnt_not_applied();
         p_ts("last sent log (%" PRIu64 ") to peer %d is not applied, cnt %d",
              peer_last_sent_idx, p.get_id(), cur_cnt);
-        if (cur_cnt >= 5) {
+        if (cur_cnt >= APPEND_ENTRIES_SAME_START_THROTTLE_THRESHOLD) {
             ulong prev_end_idx = end_idx;
             end_idx = std::min( cur_nxt_idx, last_log_idx + 1 + 1 );
             p_ts("reduce end_idx %" PRIu64 " -> %" PRIu64, prev_end_idx, end_idx);
         }
     } else {
         p.reset_cnt_not_applied();
+    }
+
+    int32 backward_probe_cnt = p.get_cnt_backward_log_probe();
+    int32 backward_probe_threshold =
+        params->append_entries_backward_probe_throttle_threshold_;
+    if ( backward_probe_threshold > 0 &&
+         backward_probe_cnt >= backward_probe_threshold &&
+         last_log_idx + 2 < end_idx ) {
+        ulong prev_end_idx = end_idx;
+        end_idx = std::min( cur_nxt_idx, last_log_idx + 1 + 1 );
+        p_ts("reduce end_idx %" PRIu64 " -> %" PRIu64
+             " for peer %d after %d backward log probes",
+             prev_end_idx, end_idx, p.get_id(), backward_probe_cnt);
     }
 
     ptr<std::vector<ptr<log_entry>>> log_entries;
@@ -628,6 +644,7 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,
             cs_new<log_entry>(0, custom_noti->serialize(), log_val_type::custom);
 
         req->log_entries().push_back(custom_noti_le);
+        p.reset_cnt_backward_log_probe();
         return req;
     }
 
@@ -1298,6 +1315,7 @@ void raft_server::handle_append_entries_resp(resp_msg& resp) {
         {
             std::lock_guard<std::mutex> l(p->get_lock());
             p->set_next_log_idx(resp.get_next_idx());
+            p->reset_cnt_backward_log_probe();
             prev_matched_idx = p->get_matched_idx();
             new_matched_idx = resp.get_next_idx() - 1;
 
@@ -1367,9 +1385,23 @@ void raft_server::handle_append_entries_resp(resp_msg& resp) {
                  resp_appendix::extra_order_msg(extra_order));
         }
 
+        bool current_term_log_probe =
+            extra_order == resp_appendix::NONE &&
+            resp.get_term() == state_->get_term();
+        bool stale_term_log_probe =
+            extra_order == resp_appendix::NONE &&
+            resp.get_term() != state_->get_term();
+        bool unknown_extra_order =
+            extra_order != resp_appendix::NONE &&
+            extra_order != resp_appendix::DO_NOT_REWIND &&
+            extra_order != resp_appendix::COMPACTED_SNAPSHOT_BOUNDARY &&
+            extra_order != resp_appendix::RECEIVING_SNAPSHOT;
+
         if (extra_order == resp_appendix::DO_NOT_REWIND) {
             // Application-level rejection. Keep peer progress unchanged.
+            p->reset_cnt_backward_log_probe();
         } else if (extra_order == resp_appendix::COMPACTED_SNAPSHOT_BOUNDARY) {
+            p->reset_cnt_backward_log_probe();
             ulong floor = p->get_next_log_idx_floor();
             ulong target = std::max(resp.get_next_idx(), floor);
             ulong max_next_idx = precommit_index_ + 1;
@@ -1398,7 +1430,13 @@ void raft_server::handle_append_entries_resp(resp_msg& resp) {
                      last_accepted_log_idx, max_next_idx);
             }
         } else {
+            if (unknown_extra_order) {
+                p->reset_cnt_backward_log_probe();
+                p_wn("unknown append response extra order from peer %d: %d",
+                     p->get_id(), (int)extra_order);
+            }
             if (extra_order == resp_appendix::RECEIVING_SNAPSHOT) {
+                p->reset_cnt_backward_log_probe();
                 p->set_snapshot_sync_is_needed(true);
                 p_in("peer %d was in snapshot sync mode, re-sending a snapshot",
                      p->get_id());
@@ -1414,19 +1452,35 @@ void raft_server::handle_append_entries_resp(resp_msg& resp) {
                          resp.get_next_idx(), floor);
                 }
                 p->set_next_log_idx(target);
+                p->reset_cnt_backward_log_probe();
             } else {
                 // if not, move one log backward.
                 // WARNING: Make sure that `next_log_idx_` shouldn't be smaller than 0.
                 if (prev_next_log) {
                     ulong floor = p->get_next_log_idx_floor();
                     if (prev_next_log - 1 >= floor) {
-                        p->set_next_log_idx(prev_next_log - 1);
+                        ulong new_next_log = prev_next_log - 1;
+                        p->set_next_log_idx(new_next_log);
+                        if (current_term_log_probe) {
+                            int32 probe_cnt = p->inc_cnt_backward_log_probe();
+                            p_tr("peer %d backward log probe: prev next idx %" PRIu64
+                                 ", new next idx %" PRIu64 ", cnt %d",
+                                 p->get_id(), prev_next_log, new_next_log, probe_cnt);
+                        } else if (stale_term_log_probe) {
+                            p->reset_cnt_backward_log_probe();
+                            p_tr("ignore stale-term backward log probe from peer %d: "
+                                 "resp term %" PRIu64 ", my term %" PRIu64,
+                                 p->get_id(), resp.get_term(), state_->get_term());
+                        }
                     } else {
+                        p->reset_cnt_backward_log_probe();
                         p_wn("skip log rewind: next_log_idx %" PRIu64
                              " would go below snapshot floor %" PRIu64
                              ", resp next_idx %" PRIu64,
                              prev_next_log - 1, floor, resp.get_next_idx());
                     }
+                } else if (current_term_log_probe || stale_term_log_probe) {
+                    p->reset_cnt_backward_log_probe();
                 }
             }
         }

--- a/src/handle_custom_notification.cxx
+++ b/src/handle_custom_notification.cxx
@@ -273,7 +273,7 @@ void raft_server::handle_custom_notification_resp(resp_msg& resp) {
     ptr<peer> p = it->second;
 
     p->set_next_log_idx(resp.get_next_idx());
+    p->reset_cnt_backward_log_probe();
 }
 
 } // namespace nuraft;
-

--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -69,6 +69,7 @@ void raft_server::clear_snapshot_sync_ctx(peer& pp) {
         destroy_user_snp_ctx(snp_ctx);
         p_tr("destroy snapshot sync ctx %p", snp_ctx.get());
     }
+    pp.reset_cnt_backward_log_probe();
     pp.set_snapshot_in_sync(nullptr);
 }
 
@@ -81,6 +82,7 @@ ptr<req_msg> raft_server::create_sync_snapshot_req(ptr<peer>& pp,
     peer& p = *pp;
     ptr<raft_params> params = ctx_->get_params();
     std::unique_lock<std::mutex> guard(p.get_lock());
+    p.reset_cnt_backward_log_probe();
     ptr<snapshot_sync_ctx> sync_ctx = p.get_snapshot_sync_ctx();
     ptr<snapshot> snp = nullptr;
     ulong prev_sync_snp_log_idx = 0;
@@ -341,6 +343,7 @@ void raft_server::handle_install_snapshot_resp(resp_msg& resp) {
     ptr<peer> p = it->second;
     if (resp.get_accepted()) {
         std::lock_guard<std::mutex> guard(p->get_lock());
+        p->reset_cnt_backward_log_probe();
         ptr<snapshot_sync_ctx> sync_ctx = p->get_snapshot_sync_ctx();
         if (sync_ctx == nullptr) {
             p_in("no snapshot sync context for this peer, drop the response");
@@ -418,6 +421,7 @@ void raft_server::handle_install_snapshot_resp_new_member(resp_msg& resp) {
         return;
     }
 
+    srv_to_join_->reset_cnt_backward_log_probe();
     if (!resp.get_accepted()) {
         p_wn("peer doesn't accept the snapshot installation request, "
              "next log idx %" PRIu64 ", "
@@ -658,4 +662,3 @@ bool raft_server::handle_snapshot_sync_req(snapshot_sync_req& req, std::unique_l
 }
 
 } // namespace nuraft;
-

--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -192,6 +192,7 @@ void peer::handle_rpc_result( ptr<peer> myself,
                 // The first request on the next connection will re-check
                 // the flag.
                 set_snapshot_sync_is_needed(false);
+                reset_cnt_backward_log_probe();
 
             } else {
                 // WARNING (MONSTOR-9378):
@@ -289,6 +290,7 @@ bool peer::recreate_rpc(ptr<srv_config>& config,
         reset_bytes_in_flight();
         set_free();
         set_manual_free();
+        reset_cnt_backward_log_probe();
         return true;
 
     } else {
@@ -327,4 +329,3 @@ void peer::reopen(context& ctx, timer_task<int32>::executor& hb_exec) {
 }
 
 } // namespace nuraft;
-

--- a/tests/unit/fake_network.cxx
+++ b/tests/unit/fake_network.cxx
@@ -290,6 +290,12 @@ size_t FakeNetwork::getNumPendingResps(const std::string& endpoint) {
     return conn->pendingResps.size();
 }
 
+ptr<req_msg> FakeNetwork::getFirstPendingReq(const std::string& endpoint) {
+    ptr<FakeClient> conn = findClient(endpoint);
+    if (!conn || conn->pendingReqs.empty()) return nullptr;
+    return conn->pendingReqs.begin()->req;
+}
+
 void FakeNetwork::stop() {
     handler = nullptr;
 }
@@ -429,4 +435,3 @@ void FakeTimer::cancel_impl(ptr<delayed_task>& task) {
 }
 
 }  // namespace nuraft;
-

--- a/tests/unit/fake_network.hxx
+++ b/tests/unit/fake_network.hxx
@@ -90,6 +90,8 @@ public:
 
     size_t getNumPendingResps(const std::string& endpoint);
 
+    ptr<req_msg> getFirstPendingReq(const std::string& endpoint);
+
     void goesOffline() { online = false; }
 
     void goesOnline() { online =  true; }
@@ -211,6 +213,28 @@ public:
             return it->second->get_next_log_idx();
         }
         return 0;
+    }
+
+    int32 getPeerBackwardLogProbeCount(raft_server* srv, int32 peer_id) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            return it->second->get_cnt_backward_log_probe();
+        }
+        return 0;
+    }
+
+    void setPeerBackwardLogProbeCount(raft_server* srv,
+                                      int32 peer_id,
+                                      int32 value) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            it->second->reset_cnt_backward_log_probe();
+            for (int32 ii = 0; ii < value; ++ii) {
+                it->second->inc_cnt_backward_log_probe();
+            }
+        }
     }
 
     bool replaceLastPendingResp(const std::string& endpoint,

--- a/tests/unit/snapshot_test.cxx
+++ b/tests/unit/snapshot_test.cxx
@@ -1272,6 +1272,8 @@ int append_rejection_unmarked_ahead_next_index_test() {
     ulong prev_next_log = 2;
     s1.fNet->setPeerNextLogIdx(s1.raftServer.get(), 3, prev_next_log);
     s1.fNet->setPeerNextLogIdxFloor(s1.raftServer.get(), 3, 0);
+    CHK_EQ( 0, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 3) );
 
     s1.fTimer->invoke(timer_task_type::heartbeat_timer);
     CHK_TRUE( s1.fNet->delieverReqTo("S3") );
@@ -1288,6 +1290,273 @@ int append_rejection_unmarked_ahead_next_index_test() {
     CHK_EQ( prev_next_log - 1,
             s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3) );
     CHK_EQ( 0, s1.fNet->getPeerNextLogIdxFloor(s1.raftServer.get(), 3) );
+    CHK_EQ( 1, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 3) );
+
+    s1.fNet->makeReqFailAll("S2");
+    s1.fNet->makeReqFailAll("S3");
+
+    print_stats(pkgs);
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+
+    f_base->destroy();
+
+    return 0;
+}
+
+int append_rejection_backward_probe_throttle_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( launch_servers( pkgs ) );
+    CHK_Z( make_group( pkgs ) );
+    for (auto& entry: pkgs) {
+        RaftPkg* pp = entry;
+        raft_params param = pp->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        param.snapshot_distance_ = 100;
+        param.max_append_size_ = 10;
+        pp->raftServer->update_params(param);
+    }
+    CHK_Z( append_and_replicate(s1, pkgs, 0, 20) );
+    CHK_NULL( s1.fNet->getLastSnapshot(s1.raftServer.get()).get() );
+
+    ulong s3_next_log = 15;
+    s1.fNet->setPeerNextLogIdx(s1.raftServer.get(), 3, s3_next_log);
+    s1.fNet->setPeerNextLogIdxFloor(s1.raftServer.get(), 3, 0);
+    CHK_EQ( 0, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 2) );
+    CHK_EQ( 0, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 3) );
+
+    s1.fTimer->invoke(timer_task_type::heartbeat_timer);
+    for (int32 ii = 1; ii <= 5; ++ii) {
+        ptr<req_msg> req = s1.fNet->getFirstPendingReq("S3");
+        CHK_NONNULL( req.get() );
+        CHK_EQ( (int)msg_type::append_entries_request, (int)req->get_type() );
+        CHK_GT( req->log_entries().size(), 1 );
+
+        CHK_TRUE( s1.fNet->delieverReqTo("S3") );
+        ptr<resp_msg> denial = cs_new<resp_msg>(
+            s1.raftServer->get_term(),
+            msg_type::append_entries_response,
+            3,
+            1,
+            s1.raftServer->get_last_log_idx() + 10,
+            false );
+        CHK_TRUE( s1.fNet->replaceLastPendingResp("S3", denial) );
+        CHK_TRUE( s1.fNet->handleRespFrom("S3") );
+
+        --s3_next_log;
+        CHK_EQ( s3_next_log,
+                s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3) );
+        CHK_EQ( ii, s1.fNet->getPeerBackwardLogProbeCount(
+                     s1.raftServer.get(), 3) );
+        CHK_EQ( 0, s1.fNet->getPeerBackwardLogProbeCount(
+                     s1.raftServer.get(), 2) );
+    }
+
+    ptr<req_msg> throttled_req = s1.fNet->getFirstPendingReq("S3");
+    CHK_NONNULL( throttled_req.get() );
+    CHK_EQ( (int)msg_type::append_entries_request,
+            (int)throttled_req->get_type() );
+    CHK_EQ( 1, throttled_req->log_entries().size() );
+    CHK_EQ( 5, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 3) );
+    CHK_EQ( 10, s1.raftServer->get_current_params().max_append_size_ );
+
+    for (int ii = 0; ii < 10 && s1.fNet->getNumPendingReqs("S2"); ++ii) {
+        CHK_TRUE( s1.fNet->execReqResp("S2") );
+    }
+    s1.fNet->setPeerNextLogIdx(s1.raftServer.get(), 2, 10);
+    s1.fNet->setPeerNextLogIdxFloor(s1.raftServer.get(), 2, 0);
+    s1.fTimer->invoke(timer_task_type::heartbeat_timer);
+    CHK_EQ( 1, s1.fNet->getNumPendingReqs("S3") );
+    ptr<req_msg> s2_req = s1.fNet->getFirstPendingReq("S2");
+    CHK_NONNULL( s2_req.get() );
+    CHK_EQ( (int)msg_type::append_entries_request, (int)s2_req->get_type() );
+    CHK_GT( s2_req->log_entries().size(), 1 );
+    CHK_EQ( 0, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 2) );
+
+    CHK_TRUE( s1.fNet->delieverReqTo("S3") );
+    CHK_TRUE( s1.fNet->handleRespFrom("S3") );
+    CHK_EQ( 0, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 3) );
+
+    for (int ii = 0; ii < 10 && s1.fNet->getNumPendingReqs("S3"); ++ii) {
+        CHK_TRUE( s1.fNet->execReqResp("S3") );
+    }
+    s1.fNet->setPeerNextLogIdx(s1.raftServer.get(), 3, 10);
+    s1.fTimer->invoke(timer_task_type::heartbeat_timer);
+    ptr<req_msg> unthrottled_req = s1.fNet->getFirstPendingReq("S3");
+    CHK_NONNULL( unthrottled_req.get() );
+    CHK_EQ( (int)msg_type::append_entries_request,
+            (int)unthrottled_req->get_type() );
+    CHK_GT( unthrottled_req->log_entries().size(), 1 );
+
+    s1.fNet->makeReqFailAll("S2");
+    s1.fNet->makeReqFailAll("S3");
+
+    print_stats(pkgs);
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+
+    f_base->destroy();
+
+    return 0;
+}
+
+int append_rejection_backward_probe_throttle_disabled_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( launch_servers( pkgs ) );
+    CHK_Z( make_group( pkgs ) );
+    for (auto& entry: pkgs) {
+        RaftPkg* pp = entry;
+        raft_params param = pp->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        param.snapshot_distance_ = 100;
+        param.max_append_size_ = 10;
+        param.with_append_entries_backward_probe_throttle_threshold(0);
+        pp->raftServer->update_params(param);
+    }
+    CHK_Z( append_and_replicate(s1, pkgs, 0, 20) );
+
+    ulong s3_next_log = 15;
+    s1.fNet->setPeerNextLogIdx(s1.raftServer.get(), 3, s3_next_log);
+    s1.fNet->setPeerNextLogIdxFloor(s1.raftServer.get(), 3, 0);
+    CHK_EQ( 0, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 3) );
+    CHK_EQ( 0, s1.raftServer->get_current_params()
+                 .append_entries_backward_probe_throttle_threshold_ );
+
+    s1.fTimer->invoke(timer_task_type::heartbeat_timer);
+    for (int32 ii = 1; ii <= 5; ++ii) {
+        ptr<req_msg> req = s1.fNet->getFirstPendingReq("S3");
+        CHK_NONNULL( req.get() );
+        CHK_EQ( (int)msg_type::append_entries_request, (int)req->get_type() );
+        CHK_GT( req->log_entries().size(), 1 );
+
+        CHK_TRUE( s1.fNet->delieverReqTo("S3") );
+        ptr<resp_msg> denial = cs_new<resp_msg>(
+            s1.raftServer->get_term(),
+            msg_type::append_entries_response,
+            3,
+            1,
+            s1.raftServer->get_last_log_idx() + 10,
+            false );
+        CHK_TRUE( s1.fNet->replaceLastPendingResp("S3", denial) );
+        CHK_TRUE( s1.fNet->handleRespFrom("S3") );
+
+        --s3_next_log;
+        CHK_EQ( s3_next_log,
+                s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3) );
+        CHK_EQ( ii, s1.fNet->getPeerBackwardLogProbeCount(
+                     s1.raftServer.get(), 3) );
+    }
+
+    ptr<req_msg> unthrottled_req = s1.fNet->getFirstPendingReq("S3");
+    CHK_NONNULL( unthrottled_req.get() );
+    CHK_EQ( (int)msg_type::append_entries_request,
+            (int)unthrottled_req->get_type() );
+    CHK_GT( unthrottled_req->log_entries().size(), 1 );
+    CHK_EQ( 5, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 3) );
+    CHK_EQ( 10, s1.raftServer->get_current_params().max_append_size_ );
+
+    s1.fNet->makeReqFailAll("S2");
+    s1.fNet->makeReqFailAll("S3");
+
+    print_stats(pkgs);
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+
+    f_base->destroy();
+
+    return 0;
+}
+
+int append_rejection_stale_term_probe_reset_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( launch_servers( pkgs ) );
+    CHK_Z( make_group( pkgs ) );
+    for (auto& entry: pkgs) {
+        RaftPkg* pp = entry;
+        raft_params param = pp->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        param.snapshot_distance_ = 100;
+        pp->raftServer->update_params(param);
+    }
+    CHK_Z( append_and_replicate(s1, pkgs, 0, 3) );
+    CHK_GT( s1.raftServer->get_term(), 0 );
+
+    s1.fNet->setPeerNextLogIdx(s1.raftServer.get(), 3, 2);
+    s1.fNet->setPeerNextLogIdxFloor(s1.raftServer.get(), 3, 0);
+    s1.fTimer->invoke(timer_task_type::heartbeat_timer);
+    CHK_TRUE( s1.fNet->delieverReqTo("S3") );
+    ptr<resp_msg> current_term_denial = cs_new<resp_msg>(
+        s1.raftServer->get_term(),
+        msg_type::append_entries_response,
+        3,
+        1,
+        s1.raftServer->get_last_log_idx() + 10,
+        false );
+    CHK_TRUE( s1.fNet->replaceLastPendingResp("S3", current_term_denial) );
+    CHK_TRUE( s1.fNet->handleRespFrom("S3") );
+    CHK_EQ( 1, s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3) );
+    CHK_EQ( 1, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 3) );
+
+    CHK_TRUE( s1.fNet->delieverReqTo("S3") );
+    ptr<resp_msg> stale_term_denial = cs_new<resp_msg>(
+        s1.raftServer->get_term() - 1,
+        msg_type::append_entries_response,
+        3,
+        1,
+        s1.raftServer->get_last_log_idx() + 10,
+        false );
+    CHK_TRUE( s1.fNet->replaceLastPendingResp("S3", stale_term_denial) );
+    CHK_TRUE( s1.fNet->handleRespFrom("S3") );
+    CHK_EQ( 0, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 3) );
 
     s1.fNet->makeReqFailAll("S2");
     s1.fNet->makeReqFailAll("S3");
@@ -1330,6 +1599,7 @@ int append_rejection_invalid_compacted_boundary_marker_test() {
     ulong prev_next_log = 2;
     ulong floor = 0;
     ulong matched_before = 1;
+    s1.fNet->setPeerBackwardLogProbeCount(s1.raftServer.get(), 3, 1);
     s1.fNet->setPeerNextLogIdx(s1.raftServer.get(), 3, prev_next_log);
     s1.fNet->setPeerNextLogIdxFloor(s1.raftServer.get(), 3, floor);
     s1.fNet->setPeerMatchedIdx(s1.raftServer.get(), 3, matched_before);
@@ -1353,6 +1623,8 @@ int append_rejection_invalid_compacted_boundary_marker_test() {
             s1.fNet->getPeerNextLogIdxFloor(s1.raftServer.get(), 3) );
     CHK_EQ( matched_before,
             s1.fNet->getPeerMatchedIdx(s1.raftServer.get(), 3) );
+    CHK_EQ( 0, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 3) );
 
     s1.fNet->makeReqFailAll("S2");
     s1.fNet->makeReqFailAll("S3");
@@ -1395,6 +1667,7 @@ int append_rejection_stale_compacted_boundary_marker_test() {
     ulong confirmed_idx = 3;
     ulong prev_next_log = confirmed_idx + 2;
     ulong floor = 0;
+    s1.fNet->setPeerBackwardLogProbeCount(s1.raftServer.get(), 3, 1);
     s1.fNet->setPeerNextLogIdx(s1.raftServer.get(), 3, prev_next_log);
     s1.fNet->setPeerNextLogIdxFloor(s1.raftServer.get(), 3, floor);
     s1.fNet->setPeerMatchedIdx(s1.raftServer.get(), 3, confirmed_idx);
@@ -1422,6 +1695,8 @@ int append_rejection_stale_compacted_boundary_marker_test() {
             s1.fNet->getPeerMatchedIdx(s1.raftServer.get(), 3) );
     CHK_EQ( confirmed_idx,
             s1.fNet->getPeerLastAcceptedLogIdx(s1.raftServer.get(), 3) );
+    CHK_EQ( 0, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 3) );
 
     s1.fNet->makeReqFailAll("S2");
     s1.fNet->makeReqFailAll("S3");
@@ -1465,9 +1740,14 @@ int append_rejection_do_not_rewind_ahead_next_index_test() {
     ulong floor = 0;
     s1.fNet->setPeerNextLogIdx(s1.raftServer.get(), 3, prev_next_log);
     s1.fNet->setPeerNextLogIdxFloor(s1.raftServer.get(), 3, floor);
+    CHK_EQ( 0, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 3) );
 
     s1.fTimer->invoke(timer_task_type::heartbeat_timer);
     CHK_TRUE( s1.fNet->delieverReqTo("S3") );
+    s1.fNet->setPeerBackwardLogProbeCount(s1.raftServer.get(), 3, 5);
+    CHK_EQ( 5, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 3) );
     ptr<resp_msg> denial = cs_new<resp_msg>(
         s1.raftServer->get_term(),
         msg_type::append_entries_response,
@@ -1483,6 +1763,80 @@ int append_rejection_do_not_rewind_ahead_next_index_test() {
             s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3) );
     CHK_EQ( floor,
             s1.fNet->getPeerNextLogIdxFloor(s1.raftServer.get(), 3) );
+    CHK_EQ( 0, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 3) );
+
+    ptr<req_msg> next_req = s1.fNet->getFirstPendingReq("S3");
+    CHK_NONNULL( next_req.get() );
+    CHK_EQ( (int)msg_type::append_entries_request, (int)next_req->get_type() );
+    CHK_GT( next_req->log_entries().size(), 1 );
+
+    s1.fNet->makeReqFailAll("S2");
+    s1.fNet->makeReqFailAll("S3");
+
+    print_stats(pkgs);
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+
+    f_base->destroy();
+
+    return 0;
+}
+
+int append_rejection_unknown_extra_order_probe_reset_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( launch_servers( pkgs ) );
+    CHK_Z( make_group( pkgs ) );
+    for (auto& entry: pkgs) {
+        RaftPkg* pp = entry;
+        raft_params param = pp->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        param.snapshot_distance_ = 100;
+        param.max_append_size_ = 10;
+        pp->raftServer->update_params(param);
+    }
+    CHK_Z( append_and_replicate(s1, pkgs, 0, 3) );
+
+    ulong prev_next_log = 2;
+    s1.fNet->setPeerNextLogIdx(s1.raftServer.get(), 3, prev_next_log);
+    s1.fNet->setPeerNextLogIdxFloor(s1.raftServer.get(), 3, 0);
+
+    s1.fTimer->invoke(timer_task_type::heartbeat_timer);
+    CHK_TRUE( s1.fNet->delieverReqTo("S3") );
+    s1.fNet->setPeerBackwardLogProbeCount(s1.raftServer.get(), 3, 5);
+    ptr<resp_msg> denial = cs_new<resp_msg>(
+        s1.raftServer->get_term(),
+        msg_type::append_entries_response,
+        3,
+        1,
+        s1.raftServer->get_last_log_idx() + 10,
+        false );
+    denial->set_ctx(make_resp_appendix_ctx(255));
+    CHK_TRUE( s1.fNet->replaceLastPendingResp("S3", denial) );
+    CHK_TRUE( s1.fNet->handleRespFrom("S3") );
+
+    CHK_EQ( prev_next_log - 1,
+            s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3) );
+    CHK_EQ( 0, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 3) );
+
+    ptr<req_msg> next_req = s1.fNet->getFirstPendingReq("S3");
+    CHK_NONNULL( next_req.get() );
+    CHK_EQ( (int)msg_type::append_entries_request, (int)next_req->get_type() );
+    CHK_GT( next_req->log_entries().size(), 1 );
 
     s1.fNet->makeReqFailAll("S2");
     s1.fNet->makeReqFailAll("S3");
@@ -1587,6 +1941,7 @@ int snapshot_rewind_floor_test() {
     s1.fNet->setPeerNextLogIdx(s1.raftServer.get(), 3, snapshot_floor);
     s1.fNet->setPeerMatchedIdx(s1.raftServer.get(), 3, 0);
     s1.fNet->setPeerNextLogIdxFloor(s1.raftServer.get(), 3, snapshot_floor);
+    s1.fNet->setPeerBackwardLogProbeCount(s1.raftServer.get(), 3, 1);
 
     // Trigger heartbeat → creates append_entries request to S3.
     s1.fTimer->invoke(timer_task_type::heartbeat_timer);
@@ -1611,12 +1966,15 @@ int snapshot_rewind_floor_test() {
     ulong after_phase1 =
         s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3);
     CHK_GTEQ( after_phase1, snapshot_floor );
+    CHK_EQ( 0, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 3) );
 
     // --- Phase 2: Test fast-move clamping ---
     // Set next_log_idx above the floor. A denial with NextIndex below the
     // floor triggers the fast-move path, but the floor must clamp it.
     s1.fNet->setPeerNextLogIdx(
         s1.raftServer.get(), 3, snapshot_floor + 5);
+    s1.fNet->setPeerBackwardLogProbeCount(s1.raftServer.get(), 3, 1);
 
     s1.fTimer->invoke(timer_task_type::heartbeat_timer);
     s1.fNet->delieverReqTo("S3");
@@ -1637,6 +1995,8 @@ int snapshot_rewind_floor_test() {
     ulong after_phase2 =
         s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3);
     CHK_GTEQ( after_phase2, snapshot_floor );
+    CHK_EQ( 0, s1.fNet->getPeerBackwardLogProbeCount(
+                 s1.raftServer.get(), 3) );
 
     // --- Phase 3: Verify recovery after floor is exercised ---
     // Restore proper state and confirm normal replication still works.
@@ -1715,6 +2075,15 @@ int main(int argc, char* argv[]) {
     ts.doTest( "append rejection unmarked ahead next index test",
                append_rejection_unmarked_ahead_next_index_test );
 
+    ts.doTest( "append rejection backward probe throttle test",
+               append_rejection_backward_probe_throttle_test );
+
+    ts.doTest( "append rejection backward probe throttle disabled test",
+               append_rejection_backward_probe_throttle_disabled_test );
+
+    ts.doTest( "append rejection stale term probe reset test",
+               append_rejection_stale_term_probe_reset_test );
+
     ts.doTest( "append rejection invalid compacted boundary marker test",
                append_rejection_invalid_compacted_boundary_marker_test );
 
@@ -1723,6 +2092,9 @@ int main(int argc, char* argv[]) {
 
     ts.doTest( "append rejection do not rewind ahead next index test",
                append_rejection_do_not_rewind_ahead_next_index_test );
+
+    ts.doTest( "append rejection unknown extra order probe reset test",
+               append_rejection_unknown_extra_order_probe_reset_test );
 
     ts.doTest( "snapshot rewind floor test",
                snapshot_rewind_floor_test );


### PR DESCRIPTION
Track consecutive one-step backward append probes on each peer and cap the next append payload to one entry after repeated rejections. Reset the probe counter on accepted appends, snapshot/custom-notification paths, reconnect/reset paths, and other non-log-mismatch responses.