### PR TITLE
Fix snapshot install livelock with background snapshot IO

### DIFF
--- a/include/libnuraft/raft_server_handler.hxx
+++ b/include/libnuraft/raft_server_handler.hxx
@@ -69,6 +69,19 @@ protected:
     static ptr<snapshot> get_last_snapshot(raft_server* srv) {
         return srv->get_last_snapshot();
     }
+
+    /**
+     * Set the last snapshot pointer in a raft_server (for testing).
+     */
+    static void set_last_snapshot(raft_server* srv, const ptr<snapshot>& snp) {
+        srv->set_last_snapshot(snp);
+    }
+
+    static ptr<req_msg> create_append_entries_req(raft_server* srv,
+                                                  ptr<peer>& pp,
+                                                  ulong custom_last_log_idx = 0) {
+        return srv->create_append_entries_req(pp, custom_last_log_idx);
+    }
 };
 
 }

--- a/include/libnuraft/snapshot_sync_ctx.hxx
+++ b/include/libnuraft/snapshot_sync_ctx.hxx
@@ -27,6 +27,7 @@ limitations under the License.
 #include "pp_util.hxx"
 #include "ptr.hxx"
 
+#include <atomic>
 #include <functional>
 #include <list>
 #include <mutex>
@@ -96,6 +97,12 @@ public:
 
     timer_helper& get_timer() { return timer_; }
 
+    bool begin_async_snapshot_request();
+    void finish_async_snapshot_request();
+    void finish_async_snapshot_transfer();
+    bool is_async_snapshot_request_in_progress() const;
+    bool is_async_snapshot_transfer_started() const;
+
 private:
     void io_thread_loop();
     bool begin_user_snp_ctx_io();
@@ -134,6 +141,9 @@ private:
     bool user_snp_ctx_io_active_ = false;
     bool user_snp_ctx_closed_ = false;
 
+    std::atomic<bool> async_snapshot_transfer_started_{false};
+    std::atomic<bool> async_snapshot_request_in_progress_{false};
+
     /**
      * Timer to check snapshot transfer timeout.
      */
@@ -156,8 +166,9 @@ public:
      * @param r Raft server instance.
      * @param p Peer instance.
      * @param h Response handler.
-     * @return `true` if a request was queued or already pending. `false` if no
-     *         safe current snapshot sync context and snapshot could be captured.
+     * @return `true` if a request was queued. `false` if another request is
+     *         already pending for this peer, or if a safe current snapshot
+     *         sync context and snapshot could not be captured.
      */
     bool push(ptr<raft_server> r,
               ptr<peer> p,
@@ -201,6 +212,7 @@ private:
     void async_io_loop();
 
     bool push(ptr<io_queue_elem>& elem);
+    void clear_dropped_request(ptr<io_queue_elem>& elem);
 
     /**
      * A dedicated thread for reading snapshot object.

--- a/include/libnuraft/snapshot_sync_ctx.hxx
+++ b/include/libnuraft/snapshot_sync_ctx.hxx
@@ -36,8 +36,6 @@ limitations under the License.
 
 #include "thread.hxx"
 
-class EventAwaiter;
-
 namespace nuraft {
 
 class peer;

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -304,10 +304,20 @@ bool raft_server::request_append_entries(ptr<peer> p) {
     }
 
     if (params->use_bg_thread_for_snapshot_io_) {
+        ptr<snapshot_sync_ctx> sync_ctx = p->get_snapshot_sync_ctx();
+        if ( sync_ctx &&
+             sync_ctx->is_async_snapshot_request_in_progress() ) {
+            check_snapshot_timeout(p);
+            snapshot_io_mgr::instance().invoke();
+            return true;
+        }
+
         // Check the current queue if previous request exists.
         if (snapshot_io_mgr::instance().has_pending_request(this, p->get_id())) {
             p_tr( "previous snapshot request for peer %d already exists",
                   p->get_id() );
+            check_snapshot_timeout(p);
+            snapshot_io_mgr::instance().invoke();
             return true;
         }
     }
@@ -519,6 +529,16 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,
          ", cur_nxt_idx: %" PRIu64 "\n",
          last_log_idx, starting_idx, cur_nxt_idx);
 
+    ptr<raft_params> params = ctx_->get_params();
+    ptr<snapshot_sync_ctx> active_sync_ctx = p.get_snapshot_sync_ctx();
+    ptr<snapshot> active_snp =
+        active_sync_ctx ? active_sync_ctx->get_snapshot() : nullptr;
+    const bool active_async_snapshot_transfer =
+        params->use_bg_thread_for_snapshot_io_ &&
+        active_sync_ctx &&
+        active_sync_ctx->is_async_snapshot_transfer_started() &&
+        active_snp;
+
     // Verify log index range.
     bool entries_valid = (last_log_idx + 1 >= starting_idx);
     if (entries_valid && pp->is_snapshot_sync_needed()) {
@@ -529,22 +549,26 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,
         // warning to the follower, blocking its election timer).
         ptr<snapshot> snp_local = get_last_snapshot();
         if (!snp_local || last_log_idx >= snp_local->get_last_log_idx()) {
-            // Either no snapshot exists (flag is stale — nothing to sync)
-            // or the peer has caught up past the snapshot. In both cases,
-            // clear the flag and proceed with normal log replication.
-            if (snp_local) {
-                p_in("peer %d log idx %" PRIu64 " has caught up past "
-                     "snapshot %" PRIu64 ", clearing stale snapshot sync "
-                     "flag before log replication",
-                     p.get_id(), last_log_idx,
-                     snp_local->get_last_log_idx());
+            if (active_async_snapshot_transfer) {
+                entries_valid = false;
             } else {
-                p_in("peer %d log idx %" PRIu64 ", no snapshot exists, "
-                     "clearing stale snapshot sync flag",
-                     p.get_id(), last_log_idx);
+                // Either no snapshot exists (flag is stale — nothing to sync)
+                // or the peer has caught up past the snapshot. In both cases,
+                // clear the flag and proceed with normal log replication.
+                if (snp_local) {
+                    p_in("peer %d log idx %" PRIu64 " has caught up past "
+                         "snapshot %" PRIu64 ", clearing stale snapshot sync "
+                         "flag before log replication",
+                         p.get_id(), last_log_idx,
+                         snp_local->get_last_log_idx());
+                } else {
+                    p_in("peer %d log idx %" PRIu64 ", no snapshot exists, "
+                         "clearing stale snapshot sync flag",
+                         p.get_id(), last_log_idx);
+                }
+                clear_snapshot_sync_ctx(p);
+                pp->set_snapshot_sync_is_needed(false);
             }
-            clear_snapshot_sync_ctx(p);
-            pp->set_snapshot_sync_is_needed(false);
         } else {
             entries_valid = false;
         }
@@ -553,7 +577,6 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,
     // Read log entries. The underlying log store may have removed some log entries
     // causing some of the requested entries to be unavailable. The log store should
     // return nullptr to indicate such errors.
-    ptr<raft_params> params = ctx_->get_params();
     ulong end_idx = std::min( cur_nxt_idx,
                               last_log_idx + 1 + params->max_append_size_ );
 
@@ -610,7 +633,8 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,
         // Required log entries are missing. First, we try to use snapshot to recover.
         // To avoid inconsistency due to smart pointer, should have local varaible
         // to increase its ref count.
-        ptr<snapshot> snp_local = get_last_snapshot();
+        ptr<snapshot> snp_local =
+            active_async_snapshot_transfer ? active_snp : get_last_snapshot();
 
         // Modified by Jung-Sang Ahn (Oct 11 2017):
         // As `reserved_log` has been newly added, need to check snapshot
@@ -623,6 +647,7 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,
             // snapshot sync anymore — clear the flag and fall through
             // to normal log replication or out-of-log-range handling.
             if ( last_log_idx >= snp_local->get_last_log_idx() &&
+                 !active_async_snapshot_transfer &&
                  pp->is_snapshot_sync_needed() ) {
                 p_in( "peer %d log idx %" PRIu64 " has caught up past "
                       "snapshot %" PRIu64 ", clearing snapshot sync flag",

--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -64,6 +64,7 @@ void raft_server::destroy_user_snp_ctx(ptr<snapshot_sync_ctx> sync_ctx) {
 void raft_server::clear_snapshot_sync_ctx(peer& pp) {
     ptr<snapshot_sync_ctx> snp_ctx = pp.get_snapshot_sync_ctx();
     if (snp_ctx) {
+        snp_ctx->finish_async_snapshot_transfer();
         destroy_user_snp_ctx(snp_ctx);
         p_tr("destroy snapshot sync ctx %p", snp_ctx.get());
     }
@@ -94,11 +95,16 @@ ptr<req_msg> raft_server::create_sync_snapshot_req(ptr<peer>& pp,
 
         if (sync_ctx->get_timer().timeout()) {
             p_in("previous sync_ctx %p timed out, reset it", sync_ctx.get());
-            destroy_user_snp_ctx(sync_ctx);
+            clear_snapshot_sync_ctx(p);
             sync_ctx.reset();
             snp.reset();
         }
     }
+
+    const bool async_snapshot_transfer_started =
+        params->use_bg_thread_for_snapshot_io_ &&
+        sync_ctx &&
+        sync_ctx->is_async_snapshot_transfer_started();
 
     // Modified by Jung-Sang Ahn, May 15 2018:
     //   Even though new snapshot has been created,
@@ -108,7 +114,10 @@ ptr<req_msg> raft_server::create_sync_snapshot_req(ptr<peer>& pp,
     // if ( !snp /*||
     //      ( last_snapshot_ &&
     //        last_snapshot_->get_last_log_idx() > snp->get_last_log_idx() )*/ ) {
-    if ( !snp || sync_ctx->get_offset() == 0 ) {
+    if ( !snp ||
+         ( sync_ctx &&
+           sync_ctx->get_offset() == 0 &&
+           !async_snapshot_transfer_started ) ) {
         snp = get_last_snapshot();
         if ( snp == nilptr ) {
             static timer_helper msg_timer(5000000);
@@ -163,15 +172,36 @@ ptr<req_msg> raft_server::create_sync_snapshot_req(ptr<peer>& pp,
     if (params->use_bg_thread_for_snapshot_io_) {
         // If async snapshot IO, push the snapshot read request to the manager
         // and immediately return here.
+        sync_ctx = p.get_snapshot_sync_ctx();
+        if (!sync_ctx)
+        {
+            return nullptr;
+        }
+
+        snp = sync_ctx->get_snapshot();
+        if (!snp)
+        {
+            return nullptr;
+        }
+
+        if (!sync_ctx->begin_async_snapshot_request())
+        {
+            succeeded_out = true;
+            snapshot_io_mgr::instance().invoke();
+            return nullptr;
+        }
+
         if (!snapshot_io_mgr::instance().push( this->shared_from_this(),
                                                pp,
                                                ( (pp == srv_to_join_)
                                                  ? ex_resp_handler_
                                                  : resp_handler_ ) ))
         {
+            clear_snapshot_sync_ctx(p);
             return nullptr;
         }
         succeeded_out = true;
+        snapshot_io_mgr::instance().invoke();
         return nullptr;
     }
     // Otherwise (sync snapshot IO), read the requested object here and then return.
@@ -403,6 +433,7 @@ void raft_server::handle_install_snapshot_resp(resp_msg& resp) {
             } else {
                 p_db("continue to sync snapshot at offset %" PRIu64,
                      resp.get_next_idx());
+                sync_ctx->finish_async_snapshot_request();
                 sync_ctx->set_offset(resp.get_next_idx());
             }
         }
@@ -459,6 +490,12 @@ void raft_server::handle_install_snapshot_resp_new_member(resp_msg& resp) {
         return;
     }
 
+    if (!resp.get_accepted()) {
+        clear_snapshot_sync_ctx(*srv_to_join_);
+        sync_log_to_new_srv(srv_to_join_->get_next_log_idx());
+        return;
+    }
+
     ptr<snapshot> snp = sync_ctx->get_snapshot();
     bool snp_install_done =
         ( snp->get_type() == snapshot::raw_binary &&
@@ -482,6 +519,7 @@ void raft_server::handle_install_snapshot_resp_new_member(resp_msg& resp) {
               srv_to_join_->get_next_log_idx(),
               srv_to_join_->get_matched_idx() );
     } else {
+        sync_ctx->finish_async_snapshot_request();
         sync_ctx->set_offset(resp.get_next_idx());
         p_db( "continue to send snapshot to new server at offset %" PRIu64 "",
               resp.get_next_idx() );

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -923,7 +923,13 @@ void raft_server::reset_peer_info() {
 void raft_server::handle_peer_resp(ptr<resp_msg>& resp, ptr<rpc_exception>& err) {
     recur_lock(lock_);
     if (err) {
-        int32 peer_id = err->req()->get_dst();
+        ptr<req_msg> req = err->req();
+        if (!req) {
+            p_wn("peer response error without request: %s", err->what());
+            return;
+        }
+
+        int32 peer_id = req->get_dst();
         ptr<peer> pp = nullptr;
         auto entry = peers_.find(peer_id);
         if (entry != peers_.end()) pp = entry->second;
@@ -933,6 +939,12 @@ void raft_server::handle_peer_resp(ptr<resp_msg>& resp, ptr<rpc_exception>& err)
             pp->inc_rpc_errs();
             rpc_errs = pp->get_rpc_errs();
 
+            if (req->get_type() == msg_type::install_snapshot_request) {
+                ptr<snapshot_sync_ctx> sync_ctx = pp->get_snapshot_sync_ctx();
+                if (sync_ctx) {
+                    sync_ctx->finish_async_snapshot_request();
+                }
+            }
             check_snapshot_timeout(pp);
         }
 
@@ -1572,12 +1584,29 @@ bool raft_server::request_leadership(int successor_id) {
 void raft_server::become_follower() {
     // stop hb for all peers
     p_in("[BECOME FOLLOWER] term %" PRIu64 "", state_->get_term());
+    ptr<raft_params> params = ctx_->get_params();
     {   std::lock_guard<std::recursive_mutex> ll(cli_lock_);
+        if (params->use_bg_thread_for_snapshot_io_) {
+            snapshot_io_mgr::instance().drop_reqs(this);
+        }
+
         for (peer_itor it = peers_.begin(); it != peers_.end(); ++it) {
             it->second->enable_hb(false);
             it->second->reset_stream();
+            ptr<snapshot_sync_ctx> sync_ctx = it->second->get_snapshot_sync_ctx();
+            if ( sync_ctx &&
+                 sync_ctx->is_async_snapshot_transfer_started() ) {
+                clear_snapshot_sync_ctx(*it->second);
+            }
         }
 
+        if (srv_to_join_) {
+            ptr<snapshot_sync_ctx> sync_ctx = srv_to_join_->get_snapshot_sync_ctx();
+            if ( sync_ctx &&
+                 sync_ctx->is_async_snapshot_transfer_started() ) {
+                clear_snapshot_sync_ctx(*srv_to_join_);
+            }
+        }
         srv_to_join_.reset();
         role_ = srv_role::follower;
         index_at_becoming_leader_ = 0;
@@ -1594,7 +1623,6 @@ void raft_server::become_follower() {
         pre_vote_.quorum_reject_count_ = 0;
         pre_vote_.no_response_failure_count_ = 0;
 
-        ptr<raft_params> params = ctx_->get_params();
         if ( params->auto_adjust_quorum_for_small_cluster_ &&
              peers_.size() == 1 &&
              params->custom_commit_quorum_size_ == 1 ) {
@@ -1731,11 +1759,20 @@ void raft_server::handle_ext_resp(ptr<resp_msg>& resp, ptr<rpc_exception>& err) 
 
 void raft_server::handle_ext_resp_err(rpc_exception& err) {
     ptr<req_msg> req = err.req();
+    if (!req) {
+        p_in("receive an rpc error response from peer server without request, %s",
+             err.what());
+        return;
+    }
     p_in( "receive an rpc error response from peer server, %s %d",
           err.what(), req->get_type() );
 
     if ( req->get_type() == msg_type::install_snapshot_request ) {
         if (srv_to_join_ && srv_to_join_->get_id() == req->get_dst()) {
+            ptr<snapshot_sync_ctx> sync_ctx = srv_to_join_->get_snapshot_sync_ctx();
+            if (sync_ctx) {
+                sync_ctx->finish_async_snapshot_request();
+            }
             bool timed_out = check_snapshot_timeout(srv_to_join_);
             if (!timed_out) {
                 // Enable temp HB to retry snapshot.

--- a/src/snapshot_sync_ctx.cxx
+++ b/src/snapshot_sync_ctx.cxx
@@ -83,6 +83,35 @@ void snapshot_sync_ctx::set_offset(ulong offset) {
     offset_ = offset;
 }
 
+bool snapshot_sync_ctx::begin_async_snapshot_request()
+{
+    async_snapshot_transfer_started_.store(true, std::memory_order_release);
+    bool expected = false;
+    return async_snapshot_request_in_progress_.compare_exchange_strong(
+        expected, true, std::memory_order_acq_rel, std::memory_order_acquire);
+}
+
+void snapshot_sync_ctx::finish_async_snapshot_request()
+{
+    async_snapshot_request_in_progress_.store(false, std::memory_order_release);
+}
+
+void snapshot_sync_ctx::finish_async_snapshot_transfer()
+{
+    async_snapshot_request_in_progress_.store(false, std::memory_order_release);
+    async_snapshot_transfer_started_.store(false, std::memory_order_release);
+}
+
+bool snapshot_sync_ctx::is_async_snapshot_request_in_progress() const
+{
+    return async_snapshot_request_in_progress_.load(std::memory_order_acquire);
+}
+
+bool snapshot_sync_ctx::is_async_snapshot_transfer_started() const
+{
+    return async_snapshot_transfer_started_.load(std::memory_order_acquire);
+}
+
 bool snapshot_sync_ctx::begin_user_snp_ctx_io()
 {
     std::lock_guard<std::mutex> lock(user_snp_ctx_lock_);
@@ -272,26 +301,41 @@ bool snapshot_io_mgr::push(ptr<raft_server> r,
                                sync_ctx,
                                p,
                                h );
-    push(elem);
-    return true;
+    return push(elem);
 }
 
 void snapshot_io_mgr::invoke() {
     io_thread_ea_->invoke();
 }
 
+void snapshot_io_mgr::clear_dropped_request(ptr<io_queue_elem>& elem) {
+    if (elem->dst_->get_snapshot_sync_ctx() == elem->sync_ctx_) {
+        elem->raft_->clear_snapshot_sync_ctx(*elem->dst_);
+    } else {
+        elem->sync_ctx_->finish_async_snapshot_transfer();
+    }
+}
+
 void snapshot_io_mgr::drop_reqs(raft_server* r) {
-    auto_lock(queue_lock_);
-    logger* l_ = r->l_.get();
-    auto entry = queue_.begin();
-    while (entry != queue_.end()) {
-        if ((*entry)->raft_.get() == r) {
-            p_tr("drop snapshot request for peer %d, raft server %p",
-                 (*entry)->dst_->get_id(), r);
-            entry = queue_.erase(entry);
-        } else {
-            entry++;
+    std::list< ptr<io_queue_elem> > reqs_to_drop;
+    {
+        auto_lock(queue_lock_);
+        logger* l_ = r->l_.get();
+        auto entry = queue_.begin();
+        while (entry != queue_.end()) {
+            if ((*entry)->raft_.get() == r) {
+                p_tr("drop snapshot request for peer %d, raft server %p",
+                     (*entry)->dst_->get_id(), r);
+                reqs_to_drop.push_back(*entry);
+                entry = queue_.erase(entry);
+            } else {
+                entry++;
+            }
         }
+    }
+
+    for (auto& elem: reqs_to_drop) {
+        clear_dropped_request(elem);
     }
 }
 
@@ -311,6 +355,16 @@ void snapshot_io_mgr::shutdown() {
     if (io_thread_.joinable()) {
         io_thread_ea_->invoke();
         io_thread_.join();
+    }
+
+    std::list< ptr<io_queue_elem> > reqs_to_drop;
+    {
+        auto_lock(queue_lock_);
+        reqs_to_drop.splice(reqs_to_drop.end(), queue_);
+    }
+
+    for (auto& elem: reqs_to_drop) {
+        clear_dropped_request(elem);
     }
 }
 
@@ -334,11 +388,53 @@ void snapshot_io_mgr::async_io_loop() {
         }
 
         for (ptr<io_queue_elem>& elem: reqs) {
+            class async_snapshot_request_guard
+            {
+            public:
+                async_snapshot_request_guard(snapshot_io_mgr& owner, ptr<io_queue_elem> elem)
+                    : owner_(owner)
+                    , elem_(elem)
+                {
+                }
+
+                ~async_snapshot_request_guard()
+                {
+                    if (active_)
+                    {
+                        elem_->sync_ctx_->finish_async_snapshot_request();
+                    }
+                }
+
+                void disarm()
+                {
+                    active_ = false;
+                }
+
+                void clear_context_if_current()
+                {
+                    if (!active_)
+                    {
+                        return;
+                    }
+
+                    recur_lock(elem_->raft_->lock_);
+                    owner_.clear_dropped_request(elem_);
+                    active_ = false;
+                }
+
+            private:
+                snapshot_io_mgr& owner_;
+                ptr<io_queue_elem> elem_;
+                bool active_ = true;
+            } request_guard(*this, elem);
+
             if (terminating_) {
-                break;
+                request_guard.clear_context_if_current();
+                continue;
             }
             if (!elem->raft_->is_leader()) {
-                break;
+                request_guard.clear_context_if_current();
+                continue;
             }
 
             int dst_id = elem->dst_->get_id();
@@ -388,10 +484,17 @@ void snapshot_io_mgr::async_io_loop() {
                 recur_lock(elem->raft_->lock_);
                 auto entry = elem->raft_->peers_.find(dst_id);
                 if (entry != elem->raft_->peers_.end()) {
-                    // If normal member (already in the peer list):
-                    //   reset the `sync_ctx` so as to retry with the newer version.
-                    elem->raft_->clear_snapshot_sync_ctx(*elem->dst_);
-                } else if (elem->raft_->srv_to_join_.get()) {
+                    if (elem->dst_->get_snapshot_sync_ctx() == elem->sync_ctx_) {
+                        // If normal member (already in the peer list):
+                        //   reset the `sync_ctx` so as to retry with the newer version.
+                        elem->raft_->clear_snapshot_sync_ctx(*elem->dst_);
+                        request_guard.disarm();
+                    } else {
+                        request_guard.clear_context_if_current();
+                    }
+                } else if ( elem->raft_->srv_to_join_.get() &&
+                            elem->raft_->srv_to_join_ == elem->dst_ &&
+                            elem->dst_->get_snapshot_sync_ctx() == elem->sync_ctx_ ) {
                     // If it is joing the server (not in the peer list),
                     // enable HB temporarily to retry the request.
                     elem->raft_->srv_to_join_snp_retry_required_ = true;
@@ -402,6 +505,7 @@ void snapshot_io_mgr::async_io_loop() {
                     // Ignore it.
                     p_wn("stale snapshot request in queue for peer %d, ignore it",
                          dst_id);
+                    request_guard.clear_context_if_current();
                 }
 
                 continue;
@@ -410,6 +514,17 @@ void snapshot_io_mgr::async_io_loop() {
 
             // Send snapshot message with the given response handler.
             recur_lock(elem->raft_->lock_);
+            if ( terminating_ ||
+                 !elem->raft_->is_leader() ||
+                 elem->dst_->get_snapshot_sync_ctx() != elem->sync_ctx_ ) {
+                p_tr("drop stale snapshot request for peer %d after read, "
+                     "object %" PRIu64 ", snapshot idx %" PRIu64
+                     ", term %" PRIu64,
+                     dst_id, obj_idx, snp_log_idx, snp_log_term);
+                request_guard.clear_context_if_current();
+                continue;
+            }
+
             ulong term = elem->raft_->state_->get_term();
             ulong commit_idx = elem->raft_->quick_commit_index_;
 
@@ -433,10 +548,14 @@ void snapshot_io_mgr::async_io_loop() {
                 elem->dst_->send_req(elem->dst_, req, elem->handler_);
                 elem->dst_->reset_ls_timer();
                 p_tr("bg thread sent message to peer %d", dst_id);
+                if (elem->dst_->is_busy()) {
+                    request_guard.disarm();
+                }
 
             } else {
                 p_db("peer %d is busy, push the request back to queue", dst_id);
                 reqs_to_return.push_back(elem);
+                request_guard.disarm();
             }
         }
 

--- a/tests/asio/asio_service_test.cxx
+++ b/tests/asio/asio_service_test.cxx
@@ -18,9 +18,11 @@ limitations under the License.
 #include "buffer_serializer.hxx"
 #include "debugging_options.hxx"
 #include "in_memory_log_store.hxx"
+#include "peer.hxx"
 #include "raft_server_handler.hxx"
 #include "raft_package_asio.hxx"
 #include "asio_test_common.hxx"
+#include "snapshot_sync_ctx.hxx"
 
 #include "event_awaiter.hxx"
 #include "test_common.h"

--- a/tests/asio/asio_service_test.cxx
+++ b/tests/asio/asio_service_test.cxx
@@ -18,6 +18,7 @@ limitations under the License.
 #include "buffer_serializer.hxx"
 #include "debugging_options.hxx"
 #include "in_memory_log_store.hxx"
+#include "raft_server_handler.hxx"
 #include "raft_package_asio.hxx"
 #include "asio_test_common.hxx"
 
@@ -43,6 +44,36 @@ using namespace raft_functional_common;
 static bool flag_bg_snapshot_io = false;
 
 namespace asio_service_test {
+
+class AsioPeerInspector : public raft_server_handler
+{
+public:
+    static bool asyncSnapshotRequestInProgress(raft_server* srv, int32 peer_id)
+    {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it == peers.end())
+        {
+            return false;
+        }
+
+        ptr<snapshot_sync_ctx> sync_ctx = it->second->get_snapshot_sync_ctx();
+        return sync_ctx && sync_ctx->is_async_snapshot_request_in_progress();
+    }
+
+    static bool asyncSnapshotTransferStarted(raft_server* srv, int32 peer_id)
+    {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it == peers.end())
+        {
+            return false;
+        }
+
+        ptr<snapshot_sync_ctx> sync_ctx = it->second->get_snapshot_sync_ctx();
+        return sync_ctx && sync_ctx->is_async_snapshot_transfer_started();
+    }
+};
 
 int make_group_test() {
     reset_log_files();
@@ -1074,6 +1105,12 @@ int snapshot_read_failure_during_join_test(size_t log_sync_gap) {
 
     // Wait until S3 completes catch-up.
     wait_for_catch_up(s1, s3);
+    if (flag_bg_snapshot_io) {
+        CHK_FALSE( AsioPeerInspector::asyncSnapshotRequestInProgress(
+                       s1.raftServer.get(), 3) );
+        CHK_FALSE( AsioPeerInspector::asyncSnapshotTransferStarted(
+                       s1.raftServer.get(), 3) );
+    }
 
     // State machine should be identical.
     CHK_OK( s2.getTestSm()->isSame( *s1.getTestSm() ) );
@@ -1150,6 +1187,12 @@ int snapshot_read_failure_for_lagging_server_test(size_t num_failures) {
 
     // Wait until S3 completes catch-up.
     wait_for_catch_up(s1, s3);
+    if (flag_bg_snapshot_io) {
+        CHK_FALSE( AsioPeerInspector::asyncSnapshotRequestInProgress(
+                       s1.raftServer.get(), 3) );
+        CHK_FALSE( AsioPeerInspector::asyncSnapshotTransferStarted(
+                       s1.raftServer.get(), 3) );
+    }
 
     // State machine should be identical.
     CHK_OK( s2.getTestSm()->isSame( *s1.getTestSm() ) );
@@ -2142,4 +2185,3 @@ int main(int argc, char** argv) {
 
     return 0;
 }
-

--- a/tests/unit/fake_network.hxx
+++ b/tests/unit/fake_network.hxx
@@ -254,8 +254,66 @@ public:
         }
     }
 
+    ulong getPeerSnapshotSyncCtxLastLogIdx(raft_server* srv, int32 peer_id) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            ptr<snapshot_sync_ctx> sync_ctx = it->second->get_snapshot_sync_ctx();
+            if (sync_ctx && sync_ctx->get_snapshot()) {
+                return sync_ctx->get_snapshot()->get_last_log_idx();
+            }
+        }
+        return 0;
+    }
+
+    void beginPeerSnapshotAsyncRequest(raft_server* srv, int32 peer_id) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            ptr<snapshot_sync_ctx> sync_ctx = it->second->get_snapshot_sync_ctx();
+            if (sync_ctx) {
+                sync_ctx->begin_async_snapshot_request();
+            }
+        }
+    }
+
+    bool getPeerAsyncSnapshotRequestInProgress(raft_server* srv, int32 peer_id) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            ptr<snapshot_sync_ctx> sync_ctx = it->second->get_snapshot_sync_ctx();
+            return sync_ctx && sync_ctx->is_async_snapshot_request_in_progress();
+        }
+        return false;
+    }
+
+    bool getPeerAsyncSnapshotTransferStarted(raft_server* srv, int32 peer_id) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            ptr<snapshot_sync_ctx> sync_ctx = it->second->get_snapshot_sync_ctx();
+            return sync_ctx && sync_ctx->is_async_snapshot_transfer_started();
+        }
+        return false;
+    }
+
     ptr<snapshot> getLastSnapshot(raft_server* srv) {
         return get_last_snapshot(srv);
+    }
+
+    void setLastSnapshot(raft_server* srv, ptr<snapshot> snp) {
+        set_last_snapshot(srv, snp);
+    }
+
+    ptr<req_msg> createAppendEntriesReq(raft_server* srv,
+                                        int32 peer_id,
+                                        ulong custom_last_log_idx = 0) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            return create_append_entries_req(srv, it->second, custom_last_log_idx);
+        }
+        return nullptr;
     }
 
 private:

--- a/tests/unit/snapshot_test.cxx
+++ b/tests/unit/snapshot_test.cxx
@@ -1110,6 +1110,199 @@ int snapshot_stale_sync_flag_test() {
     return 0;
 }
 
+int snapshot_async_request_state_lifecycle_test() {
+    ptr<cluster_config> config = cs_new<cluster_config>();
+    ptr<snapshot> snp =
+        cs_new<snapshot>(10, 3, config, 0, snapshot::logical_object);
+    snapshot_sync_ctx sync_ctx(snp, 2, 1000);
+
+    CHK_FALSE( sync_ctx.is_async_snapshot_transfer_started() );
+    CHK_FALSE( sync_ctx.is_async_snapshot_request_in_progress() );
+
+    CHK_TRUE( sync_ctx.begin_async_snapshot_request() );
+    CHK_TRUE( sync_ctx.is_async_snapshot_transfer_started() );
+    CHK_TRUE( sync_ctx.is_async_snapshot_request_in_progress() );
+
+    CHK_FALSE( sync_ctx.begin_async_snapshot_request() );
+    CHK_TRUE( sync_ctx.is_async_snapshot_transfer_started() );
+    CHK_TRUE( sync_ctx.is_async_snapshot_request_in_progress() );
+
+    sync_ctx.finish_async_snapshot_request();
+    CHK_TRUE( sync_ctx.is_async_snapshot_transfer_started() );
+    CHK_FALSE( sync_ctx.is_async_snapshot_request_in_progress() );
+
+    CHK_TRUE( sync_ctx.begin_async_snapshot_request() );
+    sync_ctx.finish_async_snapshot_transfer();
+    CHK_FALSE( sync_ctx.is_async_snapshot_transfer_started() );
+    CHK_FALSE( sync_ctx.is_async_snapshot_request_in_progress() );
+
+    return 0;
+}
+
+int async_snapshot_does_not_reselect_snapshot_at_offset_zero_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( launch_servers( pkgs ) );
+    CHK_Z( make_group( pkgs ) );
+
+    ExecArgs exec_args(&s1);
+    TestSuite::ThreadHolder hh(&exec_args, fake_executer, fake_executer_killer);
+
+    for (auto& entry: pkgs) {
+        raft_params param = entry->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        param.snapshot_distance_ = 5;
+        param.use_bg_thread_for_snapshot_io_ = true;
+        entry->raftServer->update_params(param);
+    }
+
+    for (size_t ii = 0; ii < 10; ++ii) {
+        std::string test_msg = "test" + std::to_string(ii);
+        ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+        msg->put(test_msg);
+        ptr< raft_result > ret = s1.raftServer->append_entries( {msg} );
+        CHK_TRUE( ret->get_accepted() );
+    }
+    for (int ii = 0; ii < 4; ++ii) {
+        s1.fNet->execReqResp();
+        s1.fNet->execReqResp();
+        CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    }
+
+    ptr<snapshot> original_snp =
+        s1.fNet->getLastSnapshot(s1.raftServer.get());
+    CHK_NONNULL( original_snp.get() );
+
+    ptr<snapshot> newer_snp =
+        cs_new<snapshot>( original_snp->get_last_log_idx() + 100,
+                          original_snp->get_last_log_term(),
+                          original_snp->get_last_config(),
+                          0,
+                          snapshot::logical_object );
+    s1.fNet->setLastSnapshot(s1.raftServer.get(), newer_snp);
+
+    s1.fNet->setPeerSnapshotInSync(s1.raftServer.get(), 3, original_snp);
+    s1.fNet->setPeerSnapshotSyncNeeded(s1.raftServer.get(), 3, true);
+    s1.fNet->setPeerNextLogIdx(s1.raftServer.get(), 3, 1);
+    s1.fNet->beginPeerSnapshotAsyncRequest(s1.raftServer.get(), 3);
+
+    ptr<req_msg> req =
+        s1.fNet->createAppendEntriesReq(s1.raftServer.get(), 3);
+    CHK_NULL( req.get() );
+
+    CHK_EQ( original_snp->get_last_log_idx(),
+            s1.fNet->getPeerSnapshotSyncCtxLastLogIdx(
+                s1.raftServer.get(), 3) );
+    CHK_TRUE( s1.fNet->getPeerAsyncSnapshotRequestInProgress(
+                  s1.raftServer.get(), 3) );
+    CHK_TRUE( s1.fNet->getPeerAsyncSnapshotTransferStarted(
+                  s1.raftServer.get(), 3) );
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+
+    fake_executer_killer(&exec_args);
+    hh.join();
+    CHK_Z( hh.getResult() );
+
+    f_base->destroy();
+    return 0;
+}
+
+int active_async_snapshot_context_not_cleared_by_caught_up_branch_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( launch_servers( pkgs ) );
+    CHK_Z( make_group( pkgs ) );
+
+    ExecArgs exec_args(&s1);
+    TestSuite::ThreadHolder hh(&exec_args, fake_executer, fake_executer_killer);
+
+    for (auto& entry: pkgs) {
+        raft_params param = entry->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        param.snapshot_distance_ = 5;
+        param.use_bg_thread_for_snapshot_io_ = true;
+        entry->raftServer->update_params(param);
+    }
+
+    for (size_t ii = 0; ii < 10; ++ii) {
+        std::string test_msg = "test" + std::to_string(ii);
+        ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+        msg->put(test_msg);
+        ptr< raft_result > ret = s1.raftServer->append_entries( {msg} );
+        CHK_TRUE( ret->get_accepted() );
+    }
+    for (int ii = 0; ii < 4; ++ii) {
+        s1.fNet->execReqResp();
+        s1.fNet->execReqResp();
+        CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    }
+
+    ptr<snapshot> leader_snp =
+        s1.fNet->getLastSnapshot(s1.raftServer.get());
+    CHK_NONNULL( leader_snp.get() );
+
+    s1.fNet->setPeerSnapshotInSync(s1.raftServer.get(), 3, leader_snp);
+    s1.fNet->setPeerSnapshotSyncNeeded(s1.raftServer.get(), 3, true);
+    s1.fNet->setPeerNextLogIdx(
+        s1.raftServer.get(), 3, leader_snp->get_last_log_idx() + 1);
+    s1.fNet->beginPeerSnapshotAsyncRequest(s1.raftServer.get(), 3);
+
+    ptr<req_msg> active_req =
+        s1.fNet->createAppendEntriesReq(s1.raftServer.get(), 3);
+    CHK_NULL( active_req.get() );
+    CHK_TRUE( s1.fNet->hasPeerSnapshotSyncCtx(
+                  s1.raftServer.get(), 3) );
+    CHK_TRUE( s1.fNet->getPeerAsyncSnapshotTransferStarted(
+                  s1.raftServer.get(), 3) );
+
+    s1.fNet->setPeerSnapshotInSync(s1.raftServer.get(), 3, leader_snp);
+    s1.fNet->setPeerSnapshotSyncNeeded(s1.raftServer.get(), 3, true);
+    s1.fNet->setPeerNextLogIdx(
+        s1.raftServer.get(), 3, leader_snp->get_last_log_idx() + 1);
+
+    ptr<req_msg> stale_req =
+        s1.fNet->createAppendEntriesReq(s1.raftServer.get(), 3);
+    (void)stale_req;
+    CHK_FALSE( s1.fNet->hasPeerSnapshotSyncCtx(
+                   s1.raftServer.get(), 3) );
+    CHK_FALSE( s1.fNet->getPeerSnapshotSyncNeeded(
+                   s1.raftServer.get(), 3) );
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+
+    fake_executer_killer(&exec_args);
+    hh.join();
+    CHK_Z( hh.getResult() );
+
+    f_base->destroy();
+    return 0;
+}
+
 // Test for Fix 1: create_sync_snapshot_req handles null snapshot
 // gracefully instead of calling system_exit/abort.
 //
@@ -2220,6 +2413,12 @@ int main(int argc, char* argv[]) {
 
     ts.doTest( "snapshot stale sync flag test",
                snapshot_stale_sync_flag_test );
+    ts.doTest( "snapshot async request state lifecycle test",
+               snapshot_async_request_state_lifecycle_test );
+    ts.doTest( "async snapshot does not reselect snapshot at offset zero test",
+               async_snapshot_does_not_reselect_snapshot_at_offset_zero_test );
+    ts.doTest( "active async snapshot context not cleared by caught up branch test",
+               active_async_snapshot_context_not_cleared_by_caught_up_branch_test );
 
     ts.doTest( "snapshot null snapshot join test",
                snapshot_null_snapshot_join_test );


### PR DESCRIPTION
## Problem

With `use_bg_thread_for_snapshot_io_` enabled, snapshot install to a lagging follower can livelock: the transfer restarts from object 0 forever.

On the sync path, object 0 is read and sent inside `create_sync_snapshot_req`, so `offset == 0` with a live sync context is never observed concurrently. On the async path the call only queues the read, so `offset` stays 0 for the whole first-object round trip. During that window the leader's append cycle either re-selects a newer snapshot (the `offset == 0` clause) or clears the context (the "caught up past snapshot" branch) — so the follower's object-0 ack finds no live context and is dropped, and the install restarts against a newer snapshot every time.

Observed in production on a ClickHouse Keeper cluster (~14 GB snapshots, new snapshot every ~40 s): 43 install attempts over 40 minutes, all stuck at object 0. The same snapshot transferred in 14 s once a sync-IO leader took over.

## Fix

Add per-peer pin state to `snapshot_sync_ctx`:

- `async_snapshot_transfer_started_` pins the snapshot for the whole install: no re-selection at `offset == 0`, no caught-up clear while a transfer is in flight.
- `async_snapshot_request_in_progress_` serializes one object round trip.

The pin is cleared on every exit path (response done/continue/declined, read or push failure, RPC error, sync-context timeout, leadership loss, shutdown), and the background worker revalidates leadership and context identity after the read, before sending. The timeout backstop still applies while pinned, so a dead follower cannot wedge the leader. Wire protocol unchanged.

## Testing

New unit tests (`snapshot_test.cxx`) and ASIO assertions; a deterministic ClickHouse integration test reproduces the livelock without this fix and passes with it.